### PR TITLE
Call stopSurface when window is closed to avoid failed assertion

### DIFF
--- a/ReactSkia/RNInstance.cpp
+++ b/ReactSkia/RNInstance.cpp
@@ -102,6 +102,11 @@ void RNInstance::Start(RSkSurfaceWindow *surface) {
   surface->AddComponent(provider->CreateComponent({}));
 }
 
+void RNInstance::Stop() {
+  SurfaceId surfaceId = 1;
+  fabricScheduler_->stopSurface(surfaceId);
+}
+
 void RNInstance::InitializeJSCore() {
   instance_ = std::make_unique<Instance>();
   turboModuleManager_ =

--- a/ReactSkia/RNInstance.h
+++ b/ReactSkia/RNInstance.h
@@ -18,6 +18,7 @@ class RNInstance {
   RNInstance(RNInstance &&) = default;
 
   void Start(RSkSurfaceWindow *surface);
+  void Stop();
 
  private:
   void InitializeJSCore();

--- a/ReactSkia/ReactSkiaApp.cpp
+++ b/ReactSkia/ReactSkiaApp.cpp
@@ -19,7 +19,9 @@ ReactSkiaApp::ReactSkiaApp(int argc, char **argv, void *platformData) {
   rnInstance_->Start(surface_.get());
 }
 
-ReactSkiaApp::~ReactSkiaApp() {}
+ReactSkiaApp::~ReactSkiaApp() {
+  rnInstance_->Stop();
+}
 
 void ReactSkiaApp::onIdle() {
   // Just re-paint continously


### PR DESCRIPTION
Try to fix #1 

I tried to fix by calling `Scheduler::stopSurface` on ReactSkiaApp destructor, the error message disappeared, I used the same `surfaceId` but we need a better way to handle it, maybe add it to class? 