### PR TITLE
Add MutationTest.js to test ShadowViewMutations

### DIFF
--- a/packages/react-native-skia/MutationTest.js
+++ b/packages/react-native-skia/MutationTest.js
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { useEffect, useState } from 'react';
+import { View, AppRegistry, Image, Text } from 'react-native';
+
+const SimpleViewApp = React.Node = () => {
+  const [color, setColor] = useState('#444');
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      if (color === '#444') {
+        setColor('#00ff88');
+      } else {
+        setColor('#444');
+      }
+    }, 2000);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [color]);
+  return (
+    <View
+      style={{ flex: 1,
+               flexDirection: 'column',
+               justifyContent: 'center',
+               alignItems: 'center',
+               backgroundColor: color }}>
+      <Image
+        style={{ width: 512, height: 512 }}
+        source={require('react-native/Libraries/NewAppScreen/components/logo.png')}
+      />
+      {color === '#00ff88' && (
+        <View style={{ width: 100, height: 100, backgroundColor: 'blue' }} />
+      )}
+      <Text style={{ color: '#fff', fontSize: 36,
+                     textAlign: 'center', marginTop: 32 }}>
+        React Native loves Skia</Text>
+
+    </View>
+  );
+};
+
+AppRegistry.registerComponent('SimpleViewApp', () => SimpleViewApp);


### PR DESCRIPTION
Simply to test mutations

- ShadowViewMutation::Create
- ShadowViewMutation::Delete
- ShadowViewMutation::Insert
- ShadowViewMutation::Remove
- ShadowViewMutation::Update

Since onPress is not ready yet, here to use setTimeout for state toggle. 

To generate bundle for test, use the following command:

```sh
$ yarn workspace react-native-skia run react-native bundle \                                               mutation_test
    --platform ios \
    --dev false \
    --entry-file MutationTest.js \
    --bundle-output ../../out/Debug/SimpleViewApp.bundle \
    --assets-dest ../../out/Debug
```