### PR TITLE
POC: SkPicture backed components

### DIFF
--- a/ReactSkia/MountingManager.cpp
+++ b/ReactSkia/MountingManager.cpp
@@ -32,6 +32,7 @@ void MountingManager::schedulerDidFinishTransaction(
   // auto number = transaction->getNumber();
 
   ProcessMutations(mutations, surfaceId);
+  surface_->SetNeedPainting();
 }
 
 void MountingManager::schedulerDidRequestPreliminaryViewAllocation(
@@ -125,7 +126,11 @@ void MountingManager::InsertMountInstruction(
   std::shared_ptr<RSkComponent> newChildComponent = GetComponent(mutation.newChildShadowView);
   std::shared_ptr<RSkComponent> parentComponent = GetComponent(mutation.parentShadowView);
   if (newChildComponent) {
-      newChildComponent->updateComponentData(mutation.newChildShadowView,ComponentUpdateMaskAll);
+    newChildComponent->updateComponentData(
+        surface_->width(),
+        surface_->height(),
+        mutation.newChildShadowView,
+        ComponentUpdateMaskAll);
   }
 
   if (parentComponent) {
@@ -155,18 +160,32 @@ void MountingManager::UpdateMountInstruction(
   auto &newChildShadowView = mutation.newChildShadowView;
 
   std::shared_ptr<RSkComponent> newChildComponent = GetComponent(mutation.newChildShadowView);
-  if(newChildComponent)
-  {
-       if(oldChildShadowView.props != newChildShadowView.props)
-           newChildComponent->updateComponentData(mutation.newChildShadowView,ComponentUpdateMaskProps);
-       if(oldChildShadowView.state != newChildShadowView.state)
-           newChildComponent->updateComponentData(mutation.newChildShadowView,ComponentUpdateMaskState);
-       if(oldChildShadowView.eventEmitter != newChildShadowView.eventEmitter)
-           newChildComponent->updateComponentData(mutation.newChildShadowView,ComponentUpdateMaskEventEmitter);
-       if(oldChildShadowView.layoutMetrics != newChildShadowView.layoutMetrics)
-           newChildComponent->updateComponentData(mutation.newChildShadowView,ComponentUpdateMaskLayoutMetrics);
+  if (newChildComponent) {
+    if (oldChildShadowView.props != newChildShadowView.props)
+      newChildComponent->updateComponentData(
+          surface_->width(),
+          surface_->height(),
+          mutation.newChildShadowView,
+          ComponentUpdateMaskProps);
+    if (oldChildShadowView.state != newChildShadowView.state)
+      newChildComponent->updateComponentData(
+          surface_->width(),
+          surface_->height(),
+          mutation.newChildShadowView,
+          ComponentUpdateMaskState);
+    if (oldChildShadowView.eventEmitter != newChildShadowView.eventEmitter)
+      newChildComponent->updateComponentData(
+          surface_->width(),
+          surface_->height(),
+          mutation.newChildShadowView,
+          ComponentUpdateMaskEventEmitter);
+    if (oldChildShadowView.layoutMetrics != newChildShadowView.layoutMetrics)
+      newChildComponent->updateComponentData(
+          surface_->width(),
+          surface_->height(),
+          mutation.newChildShadowView,
+          ComponentUpdateMaskLayoutMetrics);
   }
-
 }
 
 } // namespace react

--- a/ReactSkia/RSkSurfaceWindow.cpp
+++ b/ReactSkia/RSkSurfaceWindow.cpp
@@ -36,6 +36,14 @@ LayoutConstraints RSkSurfaceWindow::GetLayoutConstraints() {
   return {windowSize, windowSize};
 }
 
+int RSkSurfaceWindow::width() const {
+  return window_->width();
+}
+
+int RSkSurfaceWindow::height() const {
+  return window_->height();
+}
+
 void RSkSurfaceWindow::AddComponent(std::shared_ptr<RSkComponent> component) {
   /* FIXME: components_ list is not been used as of now */
   // components_.push_back(component);
@@ -44,6 +52,10 @@ void RSkSurfaceWindow::AddComponent(std::shared_ptr<RSkComponent> component) {
 
 void RSkSurfaceWindow::DeleteComponent(std::shared_ptr<RSkComponent> component) {
   window_->popLayer(window_->findLayer(component.get()));
+}
+
+void RSkSurfaceWindow::SetNeedPainting() {
+  window_->SetNeedPainting();
 }
 
 void RSkSurfaceWindow::RecreateWindowBackend() {

--- a/ReactSkia/RSkSurfaceWindow.h
+++ b/ReactSkia/RSkSurfaceWindow.h
@@ -30,9 +30,14 @@ class RSkSurfaceWindow {
 
   LayoutConstraints GetLayoutConstraints();
 
+  int width() const;
+  int height() const;
+
   // Components management
   void AddComponent(std::shared_ptr<RSkComponent> component);
   void DeleteComponent(std::shared_ptr<RSkComponent> component);
+
+  void SetNeedPainting();
 
  private:
   void RecreateWindowBackend();

--- a/ReactSkia/components/RSkComponent.cpp
+++ b/ReactSkia/components/RSkComponent.cpp
@@ -3,6 +3,8 @@
 #include "include/core/SkPaint.h"
 #include "include/core/SkSurface.h"
 
+#include <glog/logging.h>
+
 namespace facebook {
 namespace react {
 
@@ -15,10 +17,10 @@ RSkComponent::RSkComponent(const ShadowView &shadowView)
 RSkComponent::~RSkComponent() {}
 
 void RSkComponent::onPaint(SkSurface *surface) {
-  if (picture_) {
-    auto canvas = surface->getCanvas();
-    canvas->drawPicture(picture_);
-  }
+  DCHECK(picture_);
+
+  auto canvas = surface->getCanvas();
+  canvas->drawPicture(picture_);
 }
 
 void RSkComponent::updateComponentData(

--- a/ReactSkia/components/RSkComponent.cpp
+++ b/ReactSkia/components/RSkComponent.cpp
@@ -15,19 +15,27 @@ RSkComponent::RSkComponent(const ShadowView &shadowView)
 RSkComponent::~RSkComponent() {}
 
 void RSkComponent::onPaint(SkSurface *surface) {
-  auto canvas = surface->getCanvas();
-  OnPaint(canvas);
+  if (picture_) {
+    auto canvas = surface->getCanvas();
+    canvas->drawPicture(picture_);
+  }
 }
 
-void RSkComponent::updateComponentData(const ShadowView &newShadowView , const uint32_t updateMask) {
-   if(updateMask & ComponentUpdateMaskProps)
-      component_.props = newShadowView.props;
-   if(updateMask & ComponentUpdateMaskState)
-      component_.state = newShadowView.state;
-   if(updateMask & ComponentUpdateMaskEventEmitter)
-      component_.eventEmitter = newShadowView.eventEmitter;
-   if(updateMask & ComponentUpdateMaskLayoutMetrics)
-      component_.layoutMetrics = newShadowView.layoutMetrics;
+void RSkComponent::updateComponentData(
+    int surfaceWidth,
+    int surfaceHeight,
+    const ShadowView &newShadowView,
+    const uint32_t updateMask) {
+  if (updateMask & ComponentUpdateMaskProps)
+    component_.props = newShadowView.props;
+  if (updateMask & ComponentUpdateMaskState)
+    component_.state = newShadowView.state;
+  if (updateMask & ComponentUpdateMaskEventEmitter)
+    component_.eventEmitter = newShadowView.eventEmitter;
+  if (updateMask & ComponentUpdateMaskLayoutMetrics)
+    component_.layoutMetrics = newShadowView.layoutMetrics;
+
+  picture_ = CreatePicture(surfaceWidth, surfaceHeight);
 }
 
 void RSkComponent::mountChildComponent(

--- a/ReactSkia/components/RSkComponent.h
+++ b/ReactSkia/components/RSkComponent.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "include/core/SkCanvas.h"
+#include "include/core/SkPicture.h"
 #include "react/renderer/mounting/ShadowView.h"
 #include "sk_app/Window.h"
 #include <glog/logging.h>
@@ -43,21 +44,27 @@ class RSkComponent : public sk_app::Window::Layer {
 
   virtual ~RSkComponent();
 
-  virtual void mountChildComponent(
-    std::shared_ptr<RSkComponent> newChildComponent,
-    const int index);
+  void mountChildComponent(
+      std::shared_ptr<RSkComponent> newChildComponent,
+      const int index);
 
-  virtual void unmountChildComponent(
-    std::shared_ptr<RSkComponent> oldChildComponent,
-    const int index);
+  void unmountChildComponent(
+      std::shared_ptr<RSkComponent> oldChildComponent,
+      const int index);
 
-  virtual void updateComponentData(const ShadowView &newShadowView , const uint32_t updateMask);
+  void updateComponentData(
+      int surfaceWidth,
+      int surfaceHeight,
+      const ShadowView &newShadowView,
+      const uint32_t updateMask);
   Component getComponentData() { return component_;};
   Point getFrameOrigin() { return absOrigin_;};
   Size getFrameSize() { return component_.layoutMetrics.frame.size;};
 
  protected:
-  virtual void OnPaint(SkCanvas *canvas) = 0;
+  virtual sk_sp<SkPicture> CreatePicture(
+      int surfaceWidth,
+      int surfaceHeight) = 0;
 
  private:
   // sk_app::Window::Layer implementations
@@ -67,6 +74,7 @@ class RSkComponent : public sk_app::Window::Layer {
   RSkComponent *parent_;
   Point absOrigin_;
   Component component_;
+  sk_sp<SkPicture> picture_;
 };
 
 } // namespace react

--- a/ReactSkia/components/RSkComponentImage.cpp
+++ b/ReactSkia/components/RSkComponentImage.cpp
@@ -4,6 +4,7 @@
 #include "include/core/SkData.h"
 #include "include/core/SkImageGenerator.h"
 #include "include/core/SkPaint.h"
+#include "include/core/SkPictureRecorder.h"
 
 #include "react/renderer/components/image/ImageShadowNode.h"
 
@@ -44,13 +45,20 @@ std::unique_ptr<SkBitmap> GetAsset(const char *path) {
 RSkComponentImage::RSkComponentImage(const ShadowView &shadowView)
     : RSkComponent(shadowView) {}
 
-void RSkComponentImage::OnPaint(
-    SkCanvas *canvas) {
+sk_sp<SkPicture> RSkComponentImage::CreatePicture(
+    int surfaceWidth,
+    int surfaceHeight) {
+  SkPictureRecorder recorder;
+  auto *canvas = recorder.beginRecording(
+      SkRect::MakeXYWH(0, 0, surfaceWidth, surfaceHeight));
+  if (!canvas) {
+    return nullptr;
+  }
   auto component = getComponentData();
   auto const &imageProps =
       *std::static_pointer_cast<ImageProps const>(component.props);
   if (imageProps.sources.empty()) {
-    return;
+    return nullptr;
   }
   const auto source = imageProps.sources[0];
 
@@ -67,6 +75,8 @@ void RSkComponentImage::OnPaint(
 
     canvas->drawBitmapRect(*bitmap, rect, nullptr);
   }
+
+  return recorder.finishRecordingAsPicture();
 }
 
 } // namespace react

--- a/ReactSkia/components/RSkComponentImage.h
+++ b/ReactSkia/components/RSkComponentImage.h
@@ -10,7 +10,7 @@ class RSkComponentImage final : public RSkComponent {
   RSkComponentImage(const ShadowView &shadowView);
 
  protected:
-  void OnPaint(SkCanvas *canvas) override;
+  sk_sp<SkPicture> CreatePicture(int surfaceWidth, int surfaceHeight) override;
 };
 
 } // namespace react

--- a/ReactSkia/components/RSkComponentRootView.cpp
+++ b/ReactSkia/components/RSkComponentRootView.cpp
@@ -1,6 +1,7 @@
 #include "ReactSkia/components/RSkComponentRootView.h"
 
 #include "include/core/SkPaint.h"
+#include "include/core/SkPictureRecorder.h"
 #include "react/renderer/components/root/RootShadowNode.h"
 
 namespace facebook {
@@ -9,9 +10,19 @@ namespace react {
 RSkComponentRootView::RSkComponentRootView(const ShadowView &shadowView)
     : RSkComponent(shadowView) {}
 
-void RSkComponentRootView::OnPaint(
-    SkCanvas *canvas) {
+sk_sp<SkPicture> RSkComponentRootView::CreatePicture(
+    int surfaceWidth,
+    int surfaceHeight) {
+  SkPictureRecorder recorder;
+  auto *canvas = recorder.beginRecording(
+      SkRect::MakeXYWH(0, 0, surfaceWidth, surfaceHeight));
+  if (!canvas) {
+    return nullptr;
+  }
+
   canvas->clear(SK_ColorWHITE);
+
+  return recorder.finishRecordingAsPicture();
 }
 
 } // namespace react

--- a/ReactSkia/components/RSkComponentRootView.h
+++ b/ReactSkia/components/RSkComponentRootView.h
@@ -10,7 +10,7 @@ class RSkComponentRootView final : public RSkComponent {
   RSkComponentRootView(const ShadowView &shadowView);
 
  protected:
-  void OnPaint(SkCanvas *canvas) override;
+  sk_sp<SkPicture> CreatePicture(int surfaceWidth, int surfaceHeight) override;
 };
 
 } // namespace react

--- a/ReactSkia/components/RSkComponentText.cpp
+++ b/ReactSkia/components/RSkComponentText.cpp
@@ -2,6 +2,7 @@
 
 #include "include/core/SkFont.h"
 #include "include/core/SkPaint.h"
+#include "include/core/SkPictureRecorder.h"
 #include "react/renderer/components/text/ParagraphShadowNode.h"
 #include "react/renderer/components/text/RawTextShadowNode.h"
 #include "react/renderer/components/text/TextShadowNode.h"
@@ -14,18 +15,33 @@ namespace react {
 RSkComponentText::RSkComponentText(const ShadowView &shadowView)
     : RSkComponent(shadowView) {}
 
-void RSkComponentText::OnPaint(SkCanvas *canvas) {
+sk_sp<SkPicture> RSkComponentText::CreatePicture(
+    int surfaceWidth,
+    int surfaceHeight) {
+  return nullptr;
 }
 
 RSkComponentRawText::RSkComponentRawText(const ShadowView &shadowView)
     : RSkComponent(shadowView) {}
 
-void RSkComponentRawText::OnPaint(SkCanvas *canvas) {}
+sk_sp<SkPicture> RSkComponentRawText::CreatePicture(
+    int surfaceWidth,
+    int surfaceHeight) {
+  return nullptr;
+}
 
 RSkComponentParagraph::RSkComponentParagraph(const ShadowView &shadowView)
     : RSkComponent(shadowView) {}
 
-void RSkComponentParagraph::OnPaint(SkCanvas *canvas) {
+sk_sp<SkPicture> RSkComponentParagraph::CreatePicture(
+    int surfaceWidth,
+    int surfaceHeight) {
+  SkPictureRecorder recorder;
+  auto *canvas = recorder.beginRecording(
+      SkRect::MakeXYWH(0, 0, surfaceWidth, surfaceHeight));
+  if (!canvas) {
+    return nullptr;
+  }
   auto component = getComponentData();
   auto state =
       std::static_pointer_cast<ParagraphShadowNode::ConcreteStateT const>(
@@ -34,10 +50,14 @@ void RSkComponentParagraph::OnPaint(SkCanvas *canvas) {
       *std::static_pointer_cast<ParagraphProps const>(component.props);
   auto data = state->getData();
   auto text = data.attributedString.getString();
-  auto fontSize = !std::isnan(props.textAttributes.fontSize) ? props.textAttributes.fontSize : TextAttributes::defaultTextAttributes().fontSize;
+  auto fontSize = !std::isnan(props.textAttributes.fontSize)
+      ? props.textAttributes.fontSize
+      : TextAttributes::defaultTextAttributes().fontSize;
   float ratio = 255.9999;
-  auto color = colorComponentsFromColor(props.textAttributes.foregroundColor ? props.textAttributes.foregroundColor : TextAttributes::defaultTextAttributes().foregroundColor);
-
+  auto color = colorComponentsFromColor(
+      props.textAttributes.foregroundColor
+          ? props.textAttributes.foregroundColor
+          : TextAttributes::defaultTextAttributes().foregroundColor);
 
   SkFont font;
   font.setSubpixel(true);
@@ -59,6 +79,8 @@ void RSkComponentParagraph::OnPaint(SkCanvas *canvas) {
       framePoint.y,
       font,
       paint);
+
+  return recorder.finishRecordingAsPicture();
 }
 
 } // namespace react

--- a/ReactSkia/components/RSkComponentText.h
+++ b/ReactSkia/components/RSkComponentText.h
@@ -10,7 +10,7 @@ class RSkComponentText final : public RSkComponent {
   RSkComponentText(const ShadowView &shadowView);
 
  protected:
-  void OnPaint(SkCanvas *canvas) override;
+  sk_sp<SkPicture> CreatePicture(int surfaceWidth, int surfaceHeight) override;
 };
 
 class RSkComponentRawText final : public RSkComponent {
@@ -18,7 +18,7 @@ class RSkComponentRawText final : public RSkComponent {
   RSkComponentRawText(const ShadowView &shadowView);
 
  protected:
-  void OnPaint(SkCanvas *canvas) override;
+  sk_sp<SkPicture> CreatePicture(int surfaceWidth, int surfaceHeight) override;
 };
 
 class RSkComponentParagraph final : public RSkComponent {
@@ -26,7 +26,7 @@ class RSkComponentParagraph final : public RSkComponent {
   RSkComponentParagraph(const ShadowView &shadowView);
 
  protected:
-  void OnPaint(SkCanvas *canvas) override;
+  sk_sp<SkPicture> CreatePicture(int surfaceWidth, int surfaceHeight) override;
 };
 
 } // namespace react

--- a/ReactSkia/components/RSkComponentView.h
+++ b/ReactSkia/components/RSkComponentView.h
@@ -10,7 +10,7 @@ class RSkComponentView final : public RSkComponent {
   RSkComponentView(const ShadowView &shadowView);
 
  protected:
-  void OnPaint(SkCanvas *canvas) override;
+  sk_sp<SkPicture> CreatePicture(int surfaceWidth, int surfaceHeight) override;
 };
 
 } // namespace react

--- a/build/secondary/folly/BUILD.gn
+++ b/build/secondary/folly/BUILD.gn
@@ -4,11 +4,16 @@ config("folly_config") {
   defines = [
     "FOLLY_NO_CONFIG=1",
     "FOLLY_HAVE_CLOCK_GETTIME=1",
-    # "FOLLY_HAVE_MEMRCHR=1",
     "FOLLY_USE_LIBCPP=1",
     "FOLLY_MOBILE=1",
     "FOLLY_HAVE_PTHREAD=1",
   ]
+
+  if (is_linux) {
+    defines += [
+      "FOLLY_HAVE_MEMRCHR=1",
+    ]
+  }
 }
 
 group("folly") {

--- a/sk_app/Window.cpp
+++ b/sk_app/Window.cpp
@@ -60,6 +60,10 @@ void Window::onPaint() {
 
     markInvalProcessed();
 
+    if (!needPainting_) {
+      return;
+    }
+
     // draw into the canvas of this surface
     this->visitLayers([](Layer* layer) { layer->onPrePaint(); });
     this->visitLayers([=](Layer* layer) { layer->onPaint(backbuffer.get()); });
@@ -68,6 +72,7 @@ void Window::onPaint() {
 
     fWindowContext->swapBuffers();
     didRenderFrame();
+    needPainting_ = false;
 }
 
 void Window::onResize(int w, int h) {
@@ -118,6 +123,11 @@ GrDirectContext* Window::directContext() const {
         return nullptr;
     }
     return fWindowContext->directContext();
+}
+
+void Window::SetNeedPainting() {
+  needPainting_ = true;
+  inval();
 }
 
 void Window::inval() {

--- a/sk_app/Window.cpp
+++ b/sk_app/Window.cpp
@@ -80,6 +80,7 @@ void Window::onResize(int w, int h) {
         return;
     }
     fWindowContext->resize(w, h);
+    SetNeedPainting();
     this->visitLayers([=](Layer* layer) { layer->onResize(w, h); });
 }
 

--- a/sk_app/Window.h
+++ b/sk_app/Window.h
@@ -110,6 +110,8 @@ public:
     // Returns null if there is not a GPU backend or if the backend is not yet created.
     GrDirectContext* directContext() const;
 
+    void SetNeedPainting();
+
 protected:
     Window();
 
@@ -128,6 +130,8 @@ protected:
 
     void visitLayers(std::function<void(Layer*)> visitor);
     bool signalLayers(std::function<bool(Layer*)> visitor);
+
+    bool needPainting_ = false;
 };
 
 }   // namespace sk_app


### PR DESCRIPTION
1. Generate SkPicture at component updates.
2. `OnPaint()` will draw pre-generated SkPictures. 
3. Add SetNeedPainting to indicate if we should repaint at next vsync signal, otherwise will not do painting and reduce unused repaint.