### PR TITLE
Partial Paint/Update Support

### DIFF
--- a/ReactSkia/MountingManager.cpp
+++ b/ReactSkia/MountingManager.cpp
@@ -170,8 +170,10 @@ void MountingManager::UpdateMountInstruction(
            newChildComponent->updateComponentData(mutation.newChildShadowView,ComponentUpdateMaskEventEmitter);
        if(oldChildShadowView.layoutMetrics != newChildShadowView.layoutMetrics)
            newChildComponent->updateComponentData(mutation.newChildShadowView,ComponentUpdateMaskLayoutMetrics);
+#if USE(RNS_SHELL_PARTIAL_UPDATES)
+       surface_->compositor()->addDamageRect(newChildComponent->layer().get()->getFrame());
+#endif
   }
-
 }
 
 } // namespace react

--- a/ReactSkia/components/RSkComponent.cpp
+++ b/ReactSkia/components/RSkComponent.cpp
@@ -25,13 +25,11 @@ RSkComponent::RSkComponent(const ShadowView &shadowView)
 
 RSkComponent::~RSkComponent() {}
 
-void RSkComponent::onPaint(SkSurface *surface) {
-  if(surface) {
-    auto canvas = surface->getCanvas();
-    if(canvas)
-        RNS_PROFILE_API_OFF(componentName_ << " Paint:", OnPaint(canvas));
+void RSkComponent::onPaint(SkCanvas* canvas) {
+  if(canvas) {
+    RNS_PROFILE_API_OFF(componentName_ << " Paint:", OnPaint(canvas));
   } else {
-      RNS_LOG_ERROR("Invalid Surface ??");
+    RNS_LOG_ERROR("Invalid canvas ??");
   }
 }
 
@@ -64,8 +62,14 @@ void RSkComponent::updateComponentData(const ShadowView &newShadowView , const u
       component_.state = newShadowView.state;
    if(updateMask & ComponentUpdateMaskEventEmitter)
       component_.eventEmitter = newShadowView.eventEmitter;
-   if(updateMask & ComponentUpdateMaskLayoutMetrics)
+   if(updateMask & ComponentUpdateMaskLayoutMetrics) {
       component_.layoutMetrics = newShadowView.layoutMetrics;
+
+      Rect frame = component_.layoutMetrics.frame;
+      SkIRect frameIRect = SkIRect::MakeXYWH(frame.origin.x, frame.origin.y, frame.size.width, frame.size.height);
+      if(layer() && layer().get())
+        layer().get()->setFrame(frameIRect);
+   }
 
    if(layer_ && layer_->type() == RnsShell::LAYER_TYPE_PICTURE) {
      RNS_PROFILE_API_OFF(componentName_ << " getPicture :", static_cast<RnsShell::PictureLayer*>(layer_.get())->setPicture(getPicture()));

--- a/ReactSkia/components/RSkComponent.h
+++ b/ReactSkia/components/RSkComponent.h
@@ -59,6 +59,7 @@ class RSkComponent : public RnsShell::Layer, public std::enable_shared_from_this
   Point getFrameOrigin() { return absOrigin_;};
   Size getFrameSize() { return component_.layoutMetrics.frame.size;};
   std::shared_ptr<RnsShell::Layer> layer() { return layer_; }
+
   void requiresLayer(const ShadowView &shadowView);
 
  protected:
@@ -67,7 +68,7 @@ class RSkComponent : public RnsShell::Layer, public std::enable_shared_from_this
  private:
   sk_sp<SkPicture> getPicture();
   // RnsShell::Layer implementations
-  void onPaint(SkSurface *surface) override;
+  void onPaint(SkCanvas*) override;
 
  private:
   RSkComponent *parent_;

--- a/rns_shell/BUILD.gn
+++ b/rns_shell/BUILD.gn
@@ -21,6 +21,9 @@ config("rns_shell_config") {
     if(extra_cppflags != "") {
       defines += string_split(extra_cppflags)
     }
+    if(rns_enable_partial_updates) {
+      defines += ["USE_RNS_SHELL_PARTIAL_UPDATES"]
+    }
   }
 }
 

--- a/rns_shell/common/WindowContext.h
+++ b/rns_shell/common/WindowContext.h
@@ -31,13 +31,15 @@ public:
 
     virtual sk_sp<SkSurface> getBackbufferSurface() = 0;
 
-    virtual void swapBuffers() = 0;
+    virtual void swapBuffers(std::vector<SkIRect> &damage) = 0;
     virtual bool makeContextCurrent() = 0;
 
     virtual bool isValid() = 0;
 
     const DisplayParams& getDisplayParams() { return displayParams_; }
     virtual void setDisplayParams(const DisplayParams& params) = 0;
+
+    virtual bool hasSwapBuffersWithDamage() = 0;
 
 #ifdef RNS_SHELL_HAS_GPU_SUPPORT
     GrDirectContext* directContext() const { return context_.get(); }

--- a/rns_shell/common/WindowContext.h
+++ b/rns_shell/common/WindowContext.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "ReactSkia/utils/RnsLog.h"
+#include "ReactSkia/utils/RnsUtils.h"
 
 #include "include/core/SkRefCnt.h"
 #include "include/core/SkSurfaceProps.h"
@@ -39,7 +40,10 @@ public:
     const DisplayParams& getDisplayParams() { return displayParams_; }
     virtual void setDisplayParams(const DisplayParams& params) = 0;
 
-    virtual bool hasSwapBuffersWithDamage() = 0;
+#if USE(RNS_SHELL_PARTIAL_UPDATES)
+    virtual bool hasSwapBuffersWithDamage() = 0; // Support for swapping/flipping multiple regions of backbuffer to frontbuffer
+    virtual bool hasBufferCopy() = 0; // Support for copying frontbuffer to backbuffer. Required/used only when hasSwapBuffersWithDamage is false
+#endif
 
 #ifdef RNS_SHELL_HAS_GPU_SUPPORT
     GrDirectContext* directContext() const { return context_.get(); }

--- a/rns_shell/compositor/Compositor.cpp
+++ b/rns_shell/compositor/Compositor.cpp
@@ -47,7 +47,11 @@ Compositor::Compositor(SkRect& viewportSize, float scaleFactor)
         attributes_.scaleFactor = scaleFactor;
         attributes_.needsResize = !viewportSize.isEmpty();
     }
-    RNS_LOG_DEBUG("Native Window Handle : " << nativeWindowHandle_ << " Window Context : " << windowContext_.get() << "Back Buffer : " << backBuffer_.get());
+#if USE(RNS_SHELL_PARTIAL_UPDATES)
+    supportPartialUpdate_ = windowContext_->hasSwapBuffersWithDamage(); // TODO || Or atleast support front to back buffer copy.
+#endif
+    RNS_LOG_DEBUG("Native Window Handle : " << nativeWindowHandle_ << " Window Context : " << windowContext_.get() << "Back Buffer : " << backBuffer_.get() <<
+                  "Has swapbuffer support with damage rect : " << windowContext_->hasSwapBuffersWithDamage());
 }
 
 Compositor::~Compositor() {
@@ -66,6 +70,25 @@ void Compositor::invalidate() {
     RNS_LOG_TODO("Destroy GL context and Surface");
     windowContext_ = nullptr;
     backBuffer_ = nullptr;
+}
+
+SkRect Compositor::beginClip(SkCanvas *canvas) {
+    SkRect clipBound = SkRect::MakeEmpty();
+    if(surfaceDamage_.size() == 0)
+        return clipBound;
+
+    SkPath clipPath = SkPath();
+    for (auto& rect : surfaceDamage_) {
+        RNS_LOG_DEBUG("Damage " << rect.x() << " " << rect.y() << " " << rect.width() << " " << rect.height());
+        clipPath.addRect(rect.left(), rect.top(), rect.right(), rect.bottom());
+    }
+    if(clipPath.getBounds().isEmpty())
+        return clipBound;
+
+    canvas->clipPath(clipPath);
+    clipBound = clipPath.getBounds();
+
+    return clipBound;
 }
 
 void Compositor::renderLayerTree() {
@@ -99,8 +122,17 @@ void Compositor::renderLayerTree() {
         if (needsResize)
             glViewport(0, 0, viewportSize.width(), viewportSize.height());
 #endif
-        RNS_PROFILE_API_OFF("Render Tree Pre-Paint", rootLayer_.get()->prePaint(backBuffer_.get()));
-        RNS_PROFILE_API_OFF("Render Tree Paint", rootLayer_.get()->paint(backBuffer_.get()));
+        auto canvas = backBuffer_.get()->getCanvas();
+        SkAutoCanvasRestore save(canvas, true);
+        SkRect clipBound = beginClip(canvas);
+        PaintContext paintContext = {
+            canvas,  // canvas
+            &surfaceDamage_, // damage rects
+            clipBound, // combined clip bounds from surfaceDamage_
+            nullptr, // GrDirectContext
+        };
+        RNS_PROFILE_API_OFF("Render Tree Pre-Paint", rootLayer_.get()->prePaint(paintContext));
+        RNS_PROFILE_API_OFF("Render Tree Paint", rootLayer_.get()->paint(paintContext));
         RNS_PROFILE_API_OFF("SkSurface Flush & Submit", backBuffer_->flushAndSubmit());
 #ifdef RNS_ENABLE_FRAME_RATE_CONTROL
         {
@@ -115,7 +147,7 @@ void Compositor::renderLayerTree() {
             prevSwapTimestamp = SkTime::GetNSecs() * 1e-3;
         }
 #endif
-        RNS_PROFILE_API_OFF("SwapBuffers", windowContext_->swapBuffers());
+        RNS_PROFILE_API_OFF("SwapBuffers", windowContext_->swapBuffers(surfaceDamage_));
         window_->didRenderFrame();
     }
 }
@@ -123,6 +155,7 @@ void Compositor::renderLayerTree() {
 void Compositor::begin() {
     // Locke until render tree has rendered current tree
     std::scoped_lock lock(isMutating);
+    surfaceDamage_.clear(); // Clear the previous damage rects.
 }
 
 void Compositor::commit() {

--- a/rns_shell/compositor/Compositor.cpp
+++ b/rns_shell/compositor/Compositor.cpp
@@ -48,10 +48,11 @@ Compositor::Compositor(SkRect& viewportSize, float scaleFactor)
         attributes_.needsResize = !viewportSize.isEmpty();
     }
 #if USE(RNS_SHELL_PARTIAL_UPDATES)
-    supportPartialUpdate_ = windowContext_->hasSwapBuffersWithDamage(); // TODO || Or atleast support front to back buffer copy.
+    supportPartialUpdate_ = windowContext_->hasSwapBuffersWithDamage() || windowContext_->hasBufferCopy();
+    RNS_LOG_DEBUG("Support for Swapbuffer with damage rect : " << windowContext_->hasSwapBuffersWithDamage() <<
+                  " Support for Copy buffer : " <<  windowContext_->hasBufferCopy());
 #endif
-    RNS_LOG_DEBUG("Native Window Handle : " << nativeWindowHandle_ << " Window Context : " << windowContext_.get() << "Back Buffer : " << backBuffer_.get() <<
-                  "Has swapbuffer support with damage rect : " << windowContext_->hasSwapBuffersWithDamage());
+    RNS_LOG_DEBUG("Native Window Handle : " << nativeWindowHandle_ << " Window Context : " << windowContext_.get() << "Back Buffer : " << backBuffer_.get());
 }
 
 Compositor::~Compositor() {

--- a/rns_shell/compositor/Compositor.cpp
+++ b/rns_shell/compositor/Compositor.cpp
@@ -80,9 +80,10 @@ SkRect Compositor::beginClip(SkCanvas *canvas) {
 
     SkPath clipPath = SkPath();
     for (auto& rect : surfaceDamage_) {
-        RNS_LOG_DEBUG("Damage " << rect.x() << " " << rect.y() << " " << rect.width() << " " << rect.height());
+        RNS_LOG_DEBUG("Add Damage " << rect.x() << " " << rect.y() << " " << rect.width() << " " << rect.height());
         clipPath.addRect(rect.left(), rect.top(), rect.right(), rect.bottom());
     }
+
     if(clipPath.getBounds().isEmpty())
         return clipBound;
 

--- a/rns_shell/compositor/Compositor.h
+++ b/rns_shell/compositor/Compositor.h
@@ -34,10 +34,16 @@ public:
     void begin(); // Call this before modifying render layer tree
     void commit(); // Commit the changes in render layer tree
 
+#if USE(RNS_SHELL_PARTIAL_UPDATES)
+    bool supportsPartialUpdates() { return supportPartialUpdate_; } // Wheather compositor can support partial paint and update
+    void addDamageRect(SkIRect damage) { if(supportPartialUpdate_ && !damage.isEmpty()) surfaceDamage_.push_back(damage); }
+#endif
+
 private:
 
     void createWindowContext();
     void renderLayerTree();
+    SkRect beginClip(SkCanvas *canvas);
 
     std::mutex isMutating; // Lock the renderLayer tree while updating and rendering
 
@@ -46,6 +52,11 @@ private:
     std::unique_ptr<WindowContext> windowContext_;
     sk_sp<SkSurface> backBuffer_;
     uint64_t nativeWindowHandle_;
+
+#if USE(RNS_SHELL_PARTIAL_UPDATES)
+    bool supportPartialUpdate_;
+#endif
+    std::vector<SkIRect> surfaceDamage_;
 
     struct {
         //Lock lock;

--- a/rns_shell/compositor/layers/PictureLayer.cpp
+++ b/rns_shell/compositor/layers/PictureLayer.cpp
@@ -19,38 +19,42 @@ PictureLayer::PictureLayer()
     RNS_LOG_INFO("Picture Layer Constructed(" << this << ") with ID : " << layerId());
 }
 
-void PictureLayer::prePaint(SkSurface *surface) {
+void PictureLayer::prePaint(PaintContext& context) {
 }
 
-void PictureLayer::paint(SkSurface *surface) {
-    if(!surface) {
-        RNS_LOG_ERROR(picture_.get() << "  " << surface);
-        return;
-    }
-
-    // First paint self and then children if any
-    if(picture_.get()) {
-        auto canvas = surface->getCanvas();
-        SkAutoCanvasRestore save(canvas, true);
-        RNS_LOG_TRACE("SkPicture ( "  << picture_ << " )For " <<
-                picture_.get()->approximateOpCount() << " operations and size : " << picture_.get()->approximateBytesUsed());
-        picture()->playback(canvas);
-    }
-
+void PictureLayer::paintSelf(PaintContext& context) {
 #if !defined(GOOGLE_STRIP_LOG) || (GOOGLE_STRIP_LOG <= INFO)
     RNS_GET_TIME_STAMP_US(start);
 #endif
-
-    RNS_LOG_DEBUG("Layer (" << layerId() << ") has " << children().size() << " childrens with surface : " << surface);
-    for (auto& layer : children()) {
-        if(layer->needsPainting())
-            layer->paint(surface);
+    if(picture_.get()) {
+        RNS_LOG_DEBUG("SkPicture ( "  << picture_ << " )For " <<
+                picture_.get()->approximateOpCount() << " operations and size : " << picture_.get()->approximateBytesUsed());
+        picture()->playback(context.canvas);
     }
-
 #if !defined(GOOGLE_STRIP_LOG) || (GOOGLE_STRIP_LOG <= INFO)
     RNS_GET_TIME_STAMP_US(end);
-    RNS_LOG_TRACE("Layer (" << layerId() << ") took " <<  (end - start) << " us  to paint self and children");
+    RNS_LOG_TRACE("PictureLayer (" << layerId() << ") took " <<  (end - start) << " us to paint self");
 #endif
 }
 
+void PictureLayer::paint(PaintContext& context) {
+    RNS_LOG_DEBUG("Picture Layer (" << layerId() << ") has " << children().size() << " childrens");
+    SkAutoCanvasRestore save(context.canvas, true); // Save current clip and matrix state
+
+    // TODO Concat matrix
+    paintSelf(context);// First paint self and then children if any
+
+    if(masksToBounds()) { // Need to clip children.
+        SkRect intRect = SkRect::Make(getFrame());
+        if(!context.dirtyClipBound.isEmpty() && intRect.intersect(context.dirtyClipBound) == false) {
+            RNS_LOG_WARN("We should not call paint if it doesnt intersect with non empty dirtyClipBound...");
+        }
+        context.canvas->clipRect(intRect);
+    }
+
+    for (auto& layer : children()) {
+        if(layer->needsPainting(context))
+            layer->paint(context);
+    }
+}
 }   // namespace RnsShell

--- a/rns_shell/compositor/layers/PictureLayer.h
+++ b/rns_shell/compositor/layers/PictureLayer.h
@@ -24,8 +24,9 @@ public:
     virtual ~PictureLayer() {};
 
     SkPicture* picture() const { return picture_.get(); }
-    void prePaint(SkSurface *surface) override;
-    void paint(SkSurface *surface) override;
+    virtual void paintSelf(PaintContext& context) override;
+    void prePaint(PaintContext& context) override;
+    void paint(PaintContext& context) override;
 
     void setPicture(sk_sp<SkPicture> picture) { picture_ = picture; }
 

--- a/rns_shell/platform/graphics/gl/GLWindowContext.cpp
+++ b/rns_shell/platform/graphics/gl/GLWindowContext.cpp
@@ -81,8 +81,12 @@ sk_sp<SkSurface> GLWindowContext::getBackbufferSurface() {
     return surface_;
 }
 
-void GLWindowContext::swapBuffers() {
-    this->onSwapBuffers();
+void GLWindowContext::swapBuffers(std::vector<SkIRect> &damage) {
+    this->onSwapBuffers(damage);
+}
+
+bool GLWindowContext::hasSwapBuffersWithDamage() {
+    return this->onHasSwapBuffersWithDamage();
 }
 
 void GLWindowContext::setDisplayParams(const DisplayParams& params) {

--- a/rns_shell/platform/graphics/gl/GLWindowContext.cpp
+++ b/rns_shell/platform/graphics/gl/GLWindowContext.cpp
@@ -85,9 +85,15 @@ void GLWindowContext::swapBuffers(std::vector<SkIRect> &damage) {
     this->onSwapBuffers(damage);
 }
 
+#if USE(RNS_SHELL_PARTIAL_UPDATES)
 bool GLWindowContext::hasSwapBuffersWithDamage() {
     return this->onHasSwapBuffersWithDamage();
 }
+
+bool GLWindowContext::hasBufferCopy() {
+    return this->onHasBufferCopy();
+}
+#endif
 
 void GLWindowContext::setDisplayParams(const DisplayParams& params) {
     displayParams_ = params;

--- a/rns_shell/platform/graphics/gl/GLWindowContext.h
+++ b/rns_shell/platform/graphics/gl/GLWindowContext.h
@@ -47,7 +47,8 @@ public:
 
     bool isValid() override { return SkToBool(backendContext_.get()); }
 
-    void swapBuffers() override;
+    void swapBuffers(std::vector<SkIRect> &damage) override;
+    bool hasSwapBuffersWithDamage() override;
 
     void setDisplayParams(const DisplayParams& params) override;
     static std::unique_ptr<GLWindowContext> createContextForWindow(GLNativeWindowType windowHandle, PlatformDisplay* = nullptr);
@@ -64,7 +65,8 @@ protected:
     // onDestroyContext().
     void destroyContext();
     virtual void onDestroyContext() = 0;
-    virtual void onSwapBuffers() = 0;
+    virtual void onSwapBuffers(std::vector<SkIRect> &damage) = 0;
+    virtual bool onHasSwapBuffersWithDamage() = 0;
 
     sk_sp<const GrGLInterface> backendContext_;
     sk_sp<SkSurface>           surface_;

--- a/rns_shell/platform/graphics/gl/GLWindowContext.h
+++ b/rns_shell/platform/graphics/gl/GLWindowContext.h
@@ -12,7 +12,7 @@
 #define GL_GLEXT_PROTOTYPES 1
 #if USE(OPENGL_ES)
 #include <GLES2/gl2.h>
-#include <GLES2/gl3.h>
+#include <GLES3/gl3.h>
 #include <GLES2/gl2ext.h>
 #else
 #include <GL/gl.h>

--- a/rns_shell/platform/graphics/gl/GLWindowContext.h
+++ b/rns_shell/platform/graphics/gl/GLWindowContext.h
@@ -9,15 +9,17 @@
 
 #include "ReactSkia/utils/RnsUtils.h"
 
+#define GL_GLEXT_PROTOTYPES 1
 #if USE(OPENGL_ES)
 #include <GLES2/gl2.h>
+#include <GLES2/gl3.h>
 #include <GLES2/gl2ext.h>
 #else
-#define GL_GLEXT_PROTOTYPES 1
 #include <GL/gl.h>
 #endif // USE(OPENGL_ES)
 
 #if USE(EGL)
+#define EGL_GLEXT_PROTOTYPES 1
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #include <EGL/eglplatform.h>

--- a/rns_shell/platform/graphics/gl/GLWindowContext.h
+++ b/rns_shell/platform/graphics/gl/GLWindowContext.h
@@ -48,7 +48,10 @@ public:
     bool isValid() override { return SkToBool(backendContext_.get()); }
 
     void swapBuffers(std::vector<SkIRect> &damage) override;
+#if USE(RNS_SHELL_PARTIAL_UPDATES)
     bool hasSwapBuffersWithDamage() override;
+    bool hasBufferCopy() override;
+#endif
 
     void setDisplayParams(const DisplayParams& params) override;
     static std::unique_ptr<GLWindowContext> createContextForWindow(GLNativeWindowType windowHandle, PlatformDisplay* = nullptr);
@@ -66,8 +69,10 @@ protected:
     void destroyContext();
     virtual void onDestroyContext() = 0;
     virtual void onSwapBuffers(std::vector<SkIRect> &damage) = 0;
+#if USE(RNS_SHELL_PARTIAL_UPDATES)
     virtual bool onHasSwapBuffersWithDamage() = 0;
-
+    virtual bool onHasBufferCopy() = 0;
+#endif
     sk_sp<const GrGLInterface> backendContext_;
     sk_sp<SkSurface>           surface_;
 };

--- a/rns_shell/platform/graphics/gl/egl/GLWindowContextEGL.cpp
+++ b/rns_shell/platform/graphics/gl/egl/GLWindowContextEGL.cpp
@@ -29,7 +29,6 @@ static const EGLenum gEGLAPIVersion = EGL_OPENGL_API;
 #endif
 
 static PFNEGLSWAPBUFFERSWITHDAMAGEEXTPROC eglSwapBuffersWithDamage = nullptr;
-static bool hasGlBlitFramebuffer = false;
 
 const char* GLWindowContextEGL::errorString(int statusCode) {
     static_assert(sizeof(int) >= sizeof(EGLint), "EGLint must not be wider than int");
@@ -339,17 +338,15 @@ sk_sp<const GrGLInterface> GLWindowContextEGL::onInitializeContext() {
     glStencilMask(0xffffffff);
     glClear(GL_STENCIL_BUFFER_BIT | GL_COLOR_BUFFER_BIT);
 
-    GLint maj, min;
-    glGetIntegerv(GL_MAJOR_VERSION, &maj);
-    glGetIntegerv(GL_MINOR_VERSION, &min);
-
-    hasGlBlitFramebuffer = ((maj > 3) || ((maj == 3) && (min >= 0))); // glBlitFramebuffer supported OpenGL 3.0 onwards
-
     if (!eglQuerySurface(display, glSurface_, EGL_WIDTH, &width_)
         || !eglQuerySurface(display, glSurface_, EGL_HEIGHT, &height_)) {
         glViewport(0, 0, width_, height_);
     }
 
+
+#if USE(RNS_SHELL_PARTIAL_UPDATES) &&  USE(RNS_SHELL_COPY_BUFFERS)
+    eglInitializeOffscreenFrameBuffer();
+#endif
     swapInterval();
     return interface ? interface : GrGLMakeNativeInterface();
 }
@@ -370,6 +367,9 @@ void GLWindowContextEGL::onDestroyContext() {
         eglDestroySurface(platformDisplay_.eglDisplay(), glSurface_);
         glSurface_ = nullptr;
     }
+#if USE(RNS_SHELL_PARTIAL_UPDATES) &&  USE(RNS_SHELL_COPY_BUFFERS)
+        eglDeleteOffscreenFrameBuffer();
+#endif
 
 #if USE(WPE_RENDERER)
     destroyWPETarget();
@@ -393,19 +393,23 @@ void GLWindowContextEGL::onSwapBuffers(std::vector<SkIRect> &damage) {
 #if !defined(GOOGLE_STRIP_LOG) || (GOOGLE_STRIP_LOG <= INFO)
         RNS_GET_TIME_STAMP_US(start);
 #endif
+
+#if USE(RNS_SHELL_PARTIAL_UPDATES)
         if(eglSwapBuffersWithDamage) {
-            auto rects = RectsToInts(platformDisplay_.eglDisplay(), glSurface_, damage);
+            auto rects = rectsToInts(platformDisplay_.eglDisplay(), glSurface_, damage);
             eglSwapBuffersWithDamage(platformDisplay_.eglDisplay(), glSurface_, rects.data(), damage.size());
-        } else {
-            eglSwapBuffers(platformDisplay_.eglDisplay(), glSurface_);
-#if USE(RNS_SHELL_PARTIAL_UPDATES) && USE(RNS_SHELL_COPY_BUFFERS)
-            if(hasGlBlitFramebuffer) {
-                glReadBuffer(GL_FRONT); // Read Front
-                glDrawBuffer(GL_BACK); // Write Back
-                glBlitFramebuffer(0, 0, width_, height_, 0, 0, width_, height_, GL_COLOR_BUFFER_BIT, GL_NEAREST);
-            }
-#endif
+        } else { // Doesnt have swapBufferWithDamage extenstion support
+#if USE(RNS_SHELL_COPY_BUFFERS) // Partial updates can still be supported with offscreen buffer drawing, if enabled
+            eglBlitAndSwapBuffers();
+#else
+            eglSwapBuffers(platformDisplay_.eglDisplay(), glSurface_); // Partial update disabled
+#endif //RNS_SHELL_COPY_BUFFERS
         }
+#else
+        RNS_UNUSED(damage);
+        eglSwapBuffers(platformDisplay_.eglDisplay(), glSurface_);
+#endif // RNS_SHELL_PARTIAL_UPDATES
+
 #if !defined(GOOGLE_STRIP_LOG) || (GOOGLE_STRIP_LOG <= INFO)
         RNS_GET_TIME_STAMP_US(end);
         Performance::takeSamples(end - start);
@@ -436,7 +440,8 @@ void GLWindowContextEGL::swapInterval() {
     eglSwapInterval(platformDisplay_.eglDisplay(), displayParams_.disableVsync_ ? 0 : 1);
 }
 
-std::vector<EGLint> GLWindowContextEGL::RectsToInts(EGLDisplay display, EGLSurface surface, const std::vector<SkIRect>& rects) {
+#if USE(RNS_SHELL_PARTIAL_UPDATES)
+std::vector<EGLint> GLWindowContextEGL::rectsToInts(EGLDisplay display, EGLSurface surface, const std::vector<SkIRect>& rects) {
     std::vector<EGLint> res;
     EGLint height;
 
@@ -452,18 +457,91 @@ std::vector<EGLint> GLWindowContextEGL::RectsToInts(EGLDisplay display, EGLSurfa
     return res;
 }
 
-#if USE(RNS_SHELL_PARTIAL_UPDATES)
 bool GLWindowContextEGL::onHasSwapBuffersWithDamage() {
     return !!eglSwapBuffersWithDamage;
 }
 
 bool GLWindowContextEGL::onHasBufferCopy() {
-#if USE(RNS_SHELL_PARTIAL_UPDATES) && USE(RNS_SHELL_COPY_BUFFERS)
-    return hasGlBlitFramebuffer;
+#if USE(RNS_SHELL_COPY_BUFFERS)
+    return (offScreenFbo_ > 0);
 #else
     return false;
 #endif
 }
+
+#if USE(RNS_SHELL_COPY_BUFFERS)
+void GLWindowContextEGL::eglBlitAndSwapBuffers() {
+	static GLint viewport[4];
+
+	glGetIntegerv(GL_VIEWPORT, viewport);
+
+// Copy ReadBuffer from SourceFB and write it to DrawFB's DrawBuffer
+#if USE(OPENGL_ES)
+	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0); // Default FB
+	glBindFramebuffer(GL_READ_FRAMEBUFFER , offScreenFbo_);
+	RNS_PROFILE_API_OFF("FB Blit ", glBlitFramebuffer(0, 0, viewport[2], viewport[3], 0, 0, viewport[2], viewport[3], (GL_COLOR_BUFFER_BIT ) , GL_NEAREST));
+#else
+	RNS_PROFILE_API_OFF("FB Blit ", glBlitNamedFramebuffer(offScreenFbo_, 0,
+                                        0, 0, viewport[2], viewport[3],
+                                        0, 0, viewport[2], viewport[3],
+                                        (GL_COLOR_BUFFER_BIT ) , GL_NEAREST));
+#endif
+
+    eglSwapBuffers(platformDisplay_.eglDisplay(), glSurface_);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, 0); // Must keep default FB as readFrameBuffer
+
+#if USE(OPENGL_ES)
+    //Draw FrameBuffers
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, offScreenFbo_);
+#endif
+}
+
+void GLWindowContextEGL::eglInitializeOffscreenFrameBuffer() {
+
+    // Create FBO
+    glGenFramebuffers(1, &offScreenFbo_);
+    glBindFramebuffer(GL_FRAMEBUFFER, offScreenFbo_);
+
+    // Create Texture for Color Buffer and attach it to FBO
+    glGenTextures(1, &colorTexture_);
+    glBindTexture(GL_TEXTURE_2D, colorTexture_);
+    glTexImage2D(GL_TEXTURE_2D, 0,GL_RGBA, width_, height_, 0,GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorTexture_, 0);
+
+    // Create Texture for Depth and Stencil Buffer and attach it to FBO
+    glGenTextures(1, &depthStencilTexture_);
+    glBindTexture(GL_TEXTURE_2D, depthStencilTexture_);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH24_STENCIL8, width_, height_, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, NULL);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, depthStencilTexture_, 0);
+
+    // Cleanup in case of error
+    if(glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+        eglDeleteOffscreenFrameBuffer();
+    } else {
+        glClearStencil(0);
+        glClearColor(0, 0, 0, 0);
+        glStencilMask(0xffffffff);
+        glClear(GL_STENCIL_BUFFER_BIT | GL_COLOR_BUFFER_BIT);
+    }
+}
+
+void GLWindowContextEGL::eglDeleteOffscreenFrameBuffer() {
+    if(offScreenFbo_) {
+        glDeleteFramebuffers(1, &offScreenFbo_);
+        offScreenFbo_ = 0;
+    }
+    if(colorTexture_) {
+        glDeleteTextures(1, &colorTexture_);
+        colorTexture_ = 0;
+    }
+    if(depthStencilTexture_) {
+        glDeleteTextures(1, &depthStencilTexture_);
+        depthStencilTexture_ = 0;
+    }
+    glBindFramebuffer(GL_FRAMEBUFFER, 0); // reset to default FB
+}
+#endif //RNS_SHELL_COPY_BUFFERS
+
 #endif
 
 }  // namespace RnsShell

--- a/rns_shell/platform/graphics/gl/egl/GLWindowContextEGL.h
+++ b/rns_shell/platform/graphics/gl/egl/GLWindowContextEGL.h
@@ -38,8 +38,10 @@ public:
 
     void onSwapBuffers(std::vector<SkIRect> &damage) override;
     void onDestroyContext() override;
+#if USE(RNS_SHELL_PARTIAL_UPDATES)
     bool onHasSwapBuffersWithDamage() override;
-
+    bool onHasBufferCopy() override;
+#endif
 protected:
     sk_sp<const GrGLInterface> onInitializeContext() override;
 

--- a/rns_shell/platform/graphics/gl/egl/GLWindowContextEGL.h
+++ b/rns_shell/platform/graphics/gl/egl/GLWindowContextEGL.h
@@ -67,17 +67,32 @@ private:
 #endif
     bool makeContextCurrent() override;
     void swapInterval();
-    std::vector<EGLint> RectsToInts(EGLDisplay display, EGLSurface surface, const std::vector<SkIRect>& rects);
 
     GLNativeWindowType      window_;
 #if USE(WPE_RENDERER)
     struct wpe_renderer_backend_egl_offscreen_target* wpeTarget_ { nullptr };
 #endif
 
+#if USE(RNS_SHELL_PARTIAL_UPDATES)
+    std::vector<EGLint> rectsToInts(EGLDisplay display, EGLSurface surface, const std::vector<SkIRect>& rects);
+#if USE(RNS_SHELL_COPY_BUFFERS)
+    void eglInitializeOffscreenFrameBuffer();
+    void eglDeleteOffscreenFrameBuffer();
+    void eglBlitAndSwapBuffers();
+#endif //RNS_SHELL_COPY_BUFFERS
+#endif //RNS_SHELL_PARTIAL_UPDATES
+
     PlatformDisplay& platformDisplay_;
     EGLSurface glSurface_ { nullptr };
     EGLContext glContext_ { nullptr };
     EGLSurfaceType surfaceType_;
+
+#if USE(RNS_SHELL_PARTIAL_UPDATES) &&  USE(RNS_SHELL_COPY_BUFFERS)
+    GLuint offScreenFbo_ { 0 };
+    GLuint colorTexture_ { 0 };
+    GLuint depthStencilTexture_ { 0 };
+#endif
+
 
     typedef GLWindowContext INHERITED;
 };

--- a/rns_shell/platform/graphics/gl/egl/GLWindowContextEGL.h
+++ b/rns_shell/platform/graphics/gl/egl/GLWindowContextEGL.h
@@ -36,8 +36,9 @@ public:
 
     static bool isExtensionSupported(const char* extensionList, const char* extension);
 
-    void onSwapBuffers() override;
+    void onSwapBuffers(std::vector<SkIRect> &damage) override;
     void onDestroyContext() override;
+    bool onHasSwapBuffersWithDamage() override;
 
 protected:
     sk_sp<const GrGLInterface> onInitializeContext() override;
@@ -64,7 +65,7 @@ private:
 #endif
     bool makeContextCurrent() override;
     void swapInterval();
-
+    std::vector<EGLint> RectsToInts(EGLDisplay display, EGLSurface surface, const std::vector<SkIRect>& rects);
 
     GLNativeWindowType      window_;
 #if USE(WPE_RENDERER)

--- a/rns_shell/platform/graphics/gl/glx/GLWindowContextGLX.cpp
+++ b/rns_shell/platform/graphics/gl/glx/GLWindowContextGLX.cpp
@@ -230,7 +230,8 @@ bool GLWindowContextGLX::makeContextCurrent() {
 }
 
 
-void GLWindowContextGLX::onSwapBuffers() {
+void GLWindowContextGLX::onSwapBuffers(std::vector<SkIRect> &damage) {
+    RNS_UNUSED(damage);
     if (display_ && glContext_) {
 #if !defined(GOOGLE_STRIP_LOG) || (GOOGLE_STRIP_LOG <= INFO)
         RNS_GET_TIME_STAMP_US(start);

--- a/rns_shell/platform/graphics/gl/glx/GLWindowContextGLX.h
+++ b/rns_shell/platform/graphics/gl/glx/GLWindowContextGLX.h
@@ -28,8 +28,10 @@ public:
 
     void onSwapBuffers(std::vector<SkIRect> &damage) override;
     void onDestroyContext() override;
-    bool onHasSwapBuffersWithDamage() override { return false; }
-
+#if USE(RNS_SHELL_PARTIAL_UPDATES)
+    bool onHasSwapBuffersWithDamage() override { RNS_LOG_NOT_IMPL; return false; }
+    bool onHasBufferCopy() override { RNS_LOG_NOT_IMPL; return false; };
+#endif
 protected:
     sk_sp<const GrGLInterface> onInitializeContext() override;
 

--- a/rns_shell/platform/graphics/gl/glx/GLWindowContextGLX.h
+++ b/rns_shell/platform/graphics/gl/glx/GLWindowContextGLX.h
@@ -26,8 +26,9 @@ public:
     GLWindowContextGLX(GLNativeWindowType, GLXFBConfig, PlatformDisplay&, const DisplayParams&, GLXContext);
     ~GLWindowContextGLX() override;
 
-    void onSwapBuffers() override;
+    void onSwapBuffers(std::vector<SkIRect> &damage) override;
     void onDestroyContext() override;
+    bool onHasSwapBuffersWithDamage() override { return false; }
 
 protected:
     sk_sp<const GrGLInterface> onInitializeContext() override;

--- a/rns_shell/platform/graphics/libwpe/RasterWindowContextLibWPE.cpp
+++ b/rns_shell/platform/graphics/libwpe/RasterWindowContextLibWPE.cpp
@@ -65,5 +65,10 @@ void RasterWindowContextLibWPE::swapBuffers(std::vector<SkIRect> &damage) {
 #endif
 }
 
+#if USE(RNS_SHELL_PARTIAL_UPDATES)
+bool RasterWindowContextLibWPE::hasBufferCopy() {
+    RNS_LOG_NOT_IMPL;
+    return false;
+}
+#endif
 }  // namespace RnsShell
-

--- a/rns_shell/platform/graphics/libwpe/RasterWindowContextLibWPE.cpp
+++ b/rns_shell/platform/graphics/libwpe/RasterWindowContextLibWPE.cpp
@@ -42,7 +42,7 @@ void RasterWindowContextLibWPE::initializeContext() {
 
 sk_sp<SkSurface> RasterWindowContextLibWPE::getBackbufferSurface() { return backbufferSurface_; }
 
-void RasterWindowContextLibWPE::swapBuffers() {
+void RasterWindowContextLibWPE::swapBuffers(std::vector<SkIRect> &damage) {
     RNS_LOG_NOT_IMPL;
     // TODO : We need to blit the SkPixmap data to native window (window_) which is returned by libwpe.
     // So this part of code will be specific to display backend used in LIBWPE, so it is better to implement

--- a/rns_shell/platform/graphics/libwpe/RasterWindowContextLibWPE.h
+++ b/rns_shell/platform/graphics/libwpe/RasterWindowContextLibWPE.h
@@ -23,7 +23,10 @@ public:
     sk_sp<SkSurface> getBackbufferSurface() override;
     void swapBuffers(std::vector<SkIRect> &damage) override;
     bool makeContextCurrent() override { return true; }
+#if USE(RNS_SHELL_PARTIAL_UPDATES)
     bool hasSwapBuffersWithDamage() override { return false; }
+    bool hasBufferCopy() override;
+#endif
     bool isValid() override { return SkToBool(window_); }
     void initializeContext();
     void setDisplayParams(const DisplayParams& params) override;

--- a/rns_shell/platform/graphics/libwpe/RasterWindowContextLibWPE.h
+++ b/rns_shell/platform/graphics/libwpe/RasterWindowContextLibWPE.h
@@ -21,8 +21,9 @@ public:
     RasterWindowContextLibWPE(GLNativeWindowType , PlatformDisplay*, const DisplayParams&);
 
     sk_sp<SkSurface> getBackbufferSurface() override;
-    void swapBuffers() override;
+    void swapBuffers(std::vector<SkIRect> &damage) override;
     bool makeContextCurrent() override { return true; }
+    bool hasSwapBuffersWithDamage() override { return false; }
     bool isValid() override { return SkToBool(window_); }
     void initializeContext();
     void setDisplayParams(const DisplayParams& params) override;

--- a/rns_shell/platform/graphics/libwpe/WindowLibWPE.h
+++ b/rns_shell/platform/graphics/libwpe/WindowLibWPE.h
@@ -18,6 +18,8 @@
 #include "platform/graphics/libwpe/PlatformDisplayLibWPE.h"
 #ifdef RNS_SHELL_HAS_GPU_SUPPORT
 #include "GLWindowContext.h"
+#else
+#include "WindowContextFactory.h"
 #endif
 
 // FIXME We will need window id only when we have multipple windows and have to choose which window to update,

--- a/rns_shell/platform/graphics/x11/RasterWindowContextX11.cpp
+++ b/rns_shell/platform/graphics/x11/RasterWindowContextX11.cpp
@@ -48,7 +48,7 @@ void RasterWindowContextX11::initializeContext() {
 
 sk_sp<SkSurface> RasterWindowContextX11::getBackbufferSurface() { return backbufferSurface_; }
 
-void RasterWindowContextX11::swapBuffers() {
+void RasterWindowContextX11::swapBuffers(std::vector<SkIRect> &damage) {
 #if !defined(GOOGLE_STRIP_LOG) || (GOOGLE_STRIP_LOG <= INFO)
     RNS_GET_TIME_STAMP_US(start);
 #endif

--- a/rns_shell/platform/graphics/x11/RasterWindowContextX11.cpp
+++ b/rns_shell/platform/graphics/x11/RasterWindowContextX11.cpp
@@ -80,6 +80,14 @@ void RasterWindowContextX11::swapBuffers(std::vector<SkIRect> &damage) {
 #endif
 }
 
+#if USE(RNS_SHELL_PARTIAL_UPDATES)
+bool RasterWindowContextX11::hasBufferCopy() {
+    // With current implementation We are using offscreen bitmap to draw and then copying this bitmap to window.
+    // This means both bitmap and window has same data after frame display ( swapbuffer )
+    return true;
+}
+#endif
+
 }  // namespace RnsShell
 
 #endif // PLATFORM(X11)

--- a/rns_shell/platform/graphics/x11/RasterWindowContextX11.h
+++ b/rns_shell/platform/graphics/x11/RasterWindowContextX11.h
@@ -22,8 +22,9 @@ public:
     RasterWindowContextX11(GLNativeWindowType , PlatformDisplay*, const DisplayParams&);
 
     sk_sp<SkSurface> getBackbufferSurface() override;
-    void swapBuffers() override;
+    void swapBuffers(std::vector<SkIRect> &damage) override;
     bool makeContextCurrent() override { return true; }
+    bool hasSwapBuffersWithDamage() override { return false; }
     bool isValid() override { return SkToBool(window_); }
     void initializeContext();
     void setDisplayParams(const DisplayParams& params) override;

--- a/rns_shell/platform/graphics/x11/RasterWindowContextX11.h
+++ b/rns_shell/platform/graphics/x11/RasterWindowContextX11.h
@@ -24,7 +24,10 @@ public:
     sk_sp<SkSurface> getBackbufferSurface() override;
     void swapBuffers(std::vector<SkIRect> &damage) override;
     bool makeContextCurrent() override { return true; }
+#if USE(RNS_SHELL_PARTIAL_UPDATES)
     bool hasSwapBuffersWithDamage() override { return false; }
+    bool hasBufferCopy() override;
+#endif
     bool isValid() override { return SkToBool(window_); }
     void initializeContext();
     void setDisplayParams(const DisplayParams& params) override;

--- a/rns_shell/rns_shell.gni
+++ b/rns_shell/rns_shell.gni
@@ -19,6 +19,9 @@ declare_args() {
 
     # For platform which doesnt have gpu have to set this to false
     gl_has_gpu = true
+
+    # Use partial updates ( dirty region painting and swaping) if system support.
+    rns_enable_partial_updates = false
   }
 }
 


### PR DESCRIPTION
Added initial framework for partially painting and updating damage rects.

Two requirements to achieve this
    1. OpenGL should support Extension "Swapbuffer with damage rect" . 
    2. If the above extension is not supported then need to copy frontbuffer to backbuffer after calling swapbuffer. This is possible using glBlitFramebuffer which is supported OpenGL 3.0 onwards

Notes: 

- Works only with EGL interface. So we need to configure RNS with `gl_use_glx=false`
- Works only with static updates i.e change in color, style, border etc. 
- Any kind of transformation (rotate, scale , transition) i.e  change in dimension and position is not supported yet.