### PR TITLE
[POC] Add derived RSkView as react-native View and add isSkiaProps

### DIFF
--- a/ReactSkia/BUILD.gn
+++ b/ReactSkia/BUILD.gn
@@ -78,6 +78,11 @@ source_set("ReactSkia") {
     "components/RSkComponentText.h",
     "components/RSkComponentView.cpp",
     "components/RSkComponentView.h",
+    "components/RSkViewComponentDescriptor.h",
+    "components/RSkViewShadowNode.cpp",
+    "components/RSkViewShadowNode.h",
+    "components/RSkViewProps.cpp",
+    "components/RSkViewProps.h",
     "views/common/RSkDrawUtils.h",
     "views/common/RSkDrawUtils.cpp",
 

--- a/ReactSkia/LegacyNativeModuleRegistry.cpp
+++ b/ReactSkia/LegacyNativeModuleRegistry.cpp
@@ -37,7 +37,11 @@ class LegacyUIManagerModule : public NativeModule {
       folly::dynamic &&args) override {
     if (reactMethodId == 0) {
       if (args[0] == "RCTView") {
-        auto nativeProps = folly::dynamic::object("onLayout", true);
+        auto nativeProps = folly::dynamic::object("onLayout", true)
+          // NOTE(kudo): current react-native still partially relies on legacy UIManager to get supported view props.
+          // That's why we have to add the props here.
+          // In newer react-native should overcome this problem.
+          ("isSkiaProp", true);
         auto directEventTypes = folly::dynamic::object(
             "topLayout",
             folly::dynamic::object("registrationName", "onLayout"));

--- a/ReactSkia/components/RSkComponentProviderView.cpp
+++ b/ReactSkia/components/RSkComponentProviderView.cpp
@@ -1,7 +1,6 @@
 #include "ReactSkia/components/RSkComponentProviderView.h"
 #include "ReactSkia/components/RSkComponentView.h"
-
-#include "react/renderer/components/view/ViewComponentDescriptor.h"
+#include "ReactSkia/components/RSkViewComponentDescriptor.h"
 
 namespace facebook {
 namespace react {
@@ -9,7 +8,7 @@ namespace react {
 RSkComponentProviderView::RSkComponentProviderView() {}
 
 ComponentDescriptorProvider RSkComponentProviderView::GetDescriptorProvider() {
-  return concreteComponentDescriptorProvider<ViewComponentDescriptor>();
+  return concreteComponentDescriptorProvider<RSkViewComponentDescriptor>();
 }
 
 std::shared_ptr<RSkComponent> RSkComponentProviderView::CreateComponent(

--- a/ReactSkia/components/RSkComponentView.cpp
+++ b/ReactSkia/components/RSkComponentView.cpp
@@ -1,6 +1,6 @@
 #include "ReactSkia/components/RSkComponentView.h"
 #include "include/core/SkPaint.h"
-#include "react/renderer/components/view/ViewShadowNode.h"
+#include "ReactSkia/components/RSkViewShadowNode.h"
 #include "ReactSkia/views/common/RSkDrawUtils.h"
 #include <glog/logging.h>
 
@@ -13,7 +13,7 @@ RSkComponentView::RSkComponentView(const ShadowView &shadowView)
 
 void RSkComponentView::OnPaint(SkCanvas *canvas) {
   auto component = getComponentData();
-  auto const &viewProps = *std::static_pointer_cast<ViewProps const>(component.props);
+  auto const &viewProps = *std::static_pointer_cast<RSkViewProps const>(component.props);
   /* apply view style props */
   auto borderMetrics=viewProps.resolveBorderMetrics(component.layoutMetrics);
   Rect frame = getAbsoluteFrame();
@@ -28,6 +28,8 @@ void RSkComponentView::OnPaint(SkCanvas *canvas) {
   drawShadow(canvas,frame,borderMetrics,shadowMetrics);
   drawBackground(canvas,frame,borderMetrics,viewProps.backgroundColor,viewProps.opacity);
   drawBorder(canvas,frame,borderMetrics,viewProps.backgroundColor,viewProps.opacity);
+
+  LOG(INFO) << "ooxx isSkiaProp: " << viewProps.isSkiaProp;
 }
 
 } // namespace react

--- a/ReactSkia/components/RSkViewComponentDescriptor.h
+++ b/ReactSkia/components/RSkViewComponentDescriptor.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "ReactSkia/components/RSkViewShadowNode.h"
+#include "react/renderer/core/ConcreteComponentDescriptor.h"
+
+namespace facebook {
+namespace react {
+
+class RSkViewComponentDescriptor
+    : public ConcreteComponentDescriptor<RSkViewShadowNode> {
+ public:
+  RSkViewComponentDescriptor(ComponentDescriptorParameters const &parameters)
+      : ConcreteComponentDescriptor<RSkViewShadowNode>(parameters) {}
+};
+
+} // namespace react
+} // namespace facebook

--- a/ReactSkia/components/RSkViewProps.cpp
+++ b/ReactSkia/components/RSkViewProps.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "RSkViewProps.h"
+
+#include "react/renderer/core/propsConversions.h"
+
+namespace facebook {
+namespace react {
+
+RSkViewProps::RSkViewProps(
+    RSkViewProps const &sourceProps,
+    RawProps const &rawProps)
+    : ViewProps(sourceProps, rawProps),
+      isSkiaProp(convertRawProp(
+          rawProps,
+          "isSkiaProp",
+          sourceProps.isSkiaProp,
+          false)) {}
+
+#pragma mark - DebugStringConvertible
+
+#if RN_DEBUG_STRING_CONVERTIBLE
+SharedDebugStringConvertibleList RSkViewProps::getDebugProps() const {
+  return ViewProps::getDebugProps();
+}
+#endif
+
+} // namespace react
+} // namespace facebook

--- a/ReactSkia/components/RSkViewProps.h
+++ b/ReactSkia/components/RSkViewProps.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "react/renderer/components/view/ViewProps.h"
+
+namespace facebook {
+namespace react {
+
+class RSkViewProps;
+
+using SharedRSkViewProps = std::shared_ptr<RSkViewProps const>;
+
+class RSkViewProps : public ViewProps {
+ public:
+  RSkViewProps() = default;
+  RSkViewProps(RSkViewProps const &sourceProps, RawProps const &rawProps);
+
+#pragma mark - Props
+
+  bool isSkiaProp{false};
+
+#pragma mark - DebugStringConvertible
+
+#if RN_DEBUG_STRING_CONVERTIBLE
+  SharedDebugStringConvertibleList getDebugProps() const override;
+#endif
+};
+
+} // namespace react
+} // namespace facebook

--- a/ReactSkia/components/RSkViewShadowNode.cpp
+++ b/ReactSkia/components/RSkViewShadowNode.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "RSkViewShadowNode.h"
+#include "react/renderer/components/view/primitives.h"
+
+namespace facebook {
+namespace react {
+
+char const RSkViewComponentName[] = "View";
+
+RSkViewShadowNode::RSkViewShadowNode(
+    ShadowNodeFragment const &fragment,
+    ShadowNodeFamily::Shared const &family,
+    ShadowNodeTraits traits)
+    : ConcreteViewShadowNode(fragment, family, traits) {
+  initialize();
+}
+
+RSkViewShadowNode::RSkViewShadowNode(
+    ShadowNode const &sourceShadowNode,
+    ShadowNodeFragment const &fragment)
+    : ConcreteViewShadowNode(sourceShadowNode, fragment) {
+  initialize();
+}
+
+static bool isColorMeaningful(SharedColor const &color) noexcept {
+  if (!color) {
+    return false;
+  }
+
+  return colorComponentsFromColor(color).alpha > 0;
+}
+
+void RSkViewShadowNode::initialize() noexcept {
+  auto &viewProps = static_cast<RSkViewProps const &>(*props_);
+
+  bool formsStackingContext = !viewProps.collapsable ||
+      viewProps.pointerEvents == PointerEventsMode::None ||
+      !viewProps.nativeId.empty() || viewProps.accessible ||
+      viewProps.opacity != 1.0 || viewProps.transform != Transform{} ||
+      viewProps.elevation != 0 ||
+      (viewProps.zIndex.has_value() &&
+       viewProps.yogaStyle.positionType() != YGPositionTypeStatic) ||
+      viewProps.yogaStyle.display() == YGDisplayNone ||
+      viewProps.getClipsContentToBounds() ||
+      isColorMeaningful(viewProps.shadowColor) ||
+      viewProps.accessibilityElementsHidden ||
+      viewProps.importantForAccessibility != ImportantForAccessibility::Auto;
+
+  bool formsView = isColorMeaningful(viewProps.backgroundColor) ||
+      isColorMeaningful(viewProps.foregroundColor) ||
+      !(viewProps.yogaStyle.border() == YGStyle::Edges{});
+
+  formsView = formsView || formsStackingContext;
+
+#ifdef ANDROID
+  // Force `formsStackingContext` trait for nodes which have `formsView`.
+  // TODO: T63560216 Investigate why/how `formsView` entangled with
+  // `formsStackingContext`.
+  formsStackingContext = formsStackingContext || formsView;
+#endif
+
+  if (formsView) {
+    traits_.set(ShadowNodeTraits::Trait::FormsView);
+  } else {
+    traits_.unset(ShadowNodeTraits::Trait::FormsView);
+  }
+
+  if (formsStackingContext) {
+    traits_.set(ShadowNodeTraits::Trait::FormsStackingContext);
+  } else {
+    traits_.unset(ShadowNodeTraits::Trait::FormsStackingContext);
+  }
+}
+
+} // namespace react
+} // namespace facebook

--- a/ReactSkia/components/RSkViewShadowNode.h
+++ b/ReactSkia/components/RSkViewShadowNode.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "ReactSkia/components/RSkViewProps.h"
+#include "react/renderer/components/view/ConcreteViewShadowNode.h"
+
+namespace facebook {
+namespace react {
+
+extern const char RSkViewComponentName[];
+
+/*
+ * `ShadowNode` for <View> component.
+ */
+class RSkViewShadowNode final : public ConcreteViewShadowNode<
+                                    RSkViewComponentName,
+                                    RSkViewProps,
+                                    ViewEventEmitter> {
+ public:
+  static ShadowNodeTraits BaseTraits() {
+    auto traits = BaseShadowNode::BaseTraits();
+    traits.set(ShadowNodeTraits::Trait::View);
+    return traits;
+  }
+
+  RSkViewShadowNode(
+      ShadowNodeFragment const &fragment,
+      ShadowNodeFamily::Shared const &family,
+      ShadowNodeTraits traits);
+
+  RSkViewShadowNode(
+      ShadowNode const &sourceShadowNode,
+      ShadowNodeFragment const &fragment);
+
+ private:
+  void initialize() noexcept;
+};
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native-skia/SimpleViewApp.js
+++ b/packages/react-native-skia/SimpleViewApp.js
@@ -4,6 +4,7 @@ import { View, AppRegistry, Image, Text } from 'react-native';
 const SimpleViewApp = React.Node = () => {
   return (
     <View
+      isSkiaProp={true}
       style={{ flex: 1,
                flexDirection: 'column',
                justifyContent: 'center',


### PR DESCRIPTION
- specify `RSkViewComponentDescriptor` for View and its componentName is `View`
- based on `RSkViewComponentDescriptor`, also introduce `RSkViewProps` and `RSkViewShadowNode` and trying to derived from `ViewProps` and `ViewShadowNode` as much as possible.