### PR TITLE
Simple Image Caching 

### DIFF
--- a/ReactSkia/BUILD.gn
+++ b/ReactSkia/BUILD.gn
@@ -78,9 +78,10 @@ source_set("ReactSkia") {
     "components/RSkComponentText.h",
     "components/RSkComponentView.cpp",
     "components/RSkComponentView.h",
-    "views/common/RSkDrawUtils.h",
     "views/common/RSkDrawUtils.cpp",
-
+    "views/common/RSkDrawUtils.h",
+    "views/common/RSkImageCacheManager.cpp",
+    "views/common/RSkImageCacheManager.h",
   ]
 
   if (is_mac) {

--- a/ReactSkia/RSkSurfaceWindow.cpp
+++ b/ReactSkia/RSkSurfaceWindow.cpp
@@ -8,9 +8,18 @@ using namespace RnsShell;
 namespace facebook {
 namespace react {
 
+#ifdef RNS_SHELL_HAS_GPU_SUPPORT
+GrDirectContext* RSkSurfaceWindow::directContext=nullptr;
+#endif
+
 RSkSurfaceWindow::RSkSurfaceWindow() {
   SkRect viewPort(SkRect::MakeEmpty());
   compositor_ = Compositor::create(viewPort);
+#ifdef RNS_SHELL_HAS_GPU_SUPPORT
+  if(compositor_) {
+    setDirectContext(compositor_->getDirectContext());
+  }
+#endif
 }
 
 RSkSurfaceWindow::~RSkSurfaceWindow() {
@@ -23,6 +32,12 @@ LayoutConstraints RSkSurfaceWindow::GetLayoutConstraints() {
                   static_cast<Float>(compositor_->viewport().height())};
   return {windowSize, windowSize};
 }
+
+#ifdef RNS_SHELL_HAS_GPU_SUPPORT
+void RSkSurfaceWindow::setDirectContext(GrDirectContext* context) {
+  RSkSurfaceWindow::directContext=context;
+}
+#endif
 
 } // namespace react
 } // namespace facebook

--- a/ReactSkia/RSkSurfaceWindow.h
+++ b/ReactSkia/RSkSurfaceWindow.h
@@ -23,6 +23,13 @@ class RSkSurfaceWindow {
 
   LayoutConstraints GetLayoutConstraints();
 
+#ifdef RNS_SHELL_HAS_GPU_SUPPORT
+// Interfaces to expose direct context of GPU backend
+  static GrDirectContext* directContext;
+  static void setDirectContext(GrDirectContext*);
+  static GrDirectContext* getDirectContext(){return  RSkSurfaceWindow::directContext;};
+#endif
+
  private:
   void RecreateWindowBackend();
 

--- a/ReactSkia/ReactSkiaApp.cpp
+++ b/ReactSkia/ReactSkiaApp.cpp
@@ -6,6 +6,8 @@
 #include "include/core/SkSurface.h"
 #include "include/effects/SkGradientShader.h"
 
+#include "ReactSkia/views/common/RSkImageCacheManager.h"
+
 using namespace RnsShell;
 
 Application *Application::Create(int argc, char **argv) {
@@ -16,6 +18,7 @@ ReactSkiaApp::ReactSkiaApp(int argc, char **argv) {
   rnInstance_ = std::make_unique<facebook::react::RNInstance>();
   surface_ = std::make_unique<facebook::react::RSkSurfaceWindow>();
   SkGraphics::Init();
+  facebook::react::RSkImageCacheManager::configure();//Needs to be called after Gpu backend created,So calling here
   rnInstance_->Start(surface_.get());
 }
 

--- a/ReactSkia/components/RSkComponentImage.cpp
+++ b/ReactSkia/components/RSkComponentImage.cpp
@@ -1,44 +1,17 @@
 #include "ReactSkia/components/RSkComponentImage.h"
-#include "include/core/SkBitmap.h"
-#include "include/core/SkData.h"
-#include "include/core/SkImageGenerator.h"
 #include "include/core/SkPaint.h"
 #include "ReactSkia/views/common/RSkDrawUtils.h"
+#include "ReactSkia/views/common/RSkImageCacheManager.h"
 #include "react/renderer/components/image/ImageShadowNode.h"
+
+#include "ReactSkia/utils/RnsLog.h"
+#include "ReactSkia/utils/RnsUtils.h"
 
 namespace facebook {
 namespace react {
 
 using namespace RSkDrawUtils;
-
-namespace {
-std::unique_ptr<SkBitmap> GetAsset(const char *path) {
-  sk_sp<SkData> data = SkData::MakeFromFileName(path);
-  if (!data) {
-    RNS_LOG_ERROR (
-        "RSkComponentImage::_::GetAsset() - Unable to make SkData from path: "
-        << path);
-    return nullptr;
-  }
-
-  std::unique_ptr<SkImageGenerator> gen(
-      SkImageGenerator::MakeFromEncoded(std::move(data)));
-  if (!gen) {
-    return nullptr;
-  }
-  auto bitmap = std::make_unique<SkBitmap>();
-  bool success = gen && bitmap->tryAllocPixels(gen->getInfo()) &&
-      gen->getPixels(
-          gen->getInfo().makeColorSpace(nullptr),
-          bitmap->getPixels(),
-          bitmap->rowBytes());
-  if (!success) {
-    return nullptr;
-  }
-  return bitmap;
-}
-
-} // namespace
+using namespace RSkImageCacheManager;
 
 RSkComponentImage::RSkComponentImage(const ShadowView &shadowView)
     : RSkComponent(shadowView) {}
@@ -56,15 +29,24 @@ void RSkComponentImage::OnPaint(
   if (source.type == ImageSource::Type::Local && !source.uri.empty()) {
     assert(source.uri.substr(0, 14) == "file://assets/");
     std::string path = "./" + source.uri.substr(7);
-    auto bitmap = GetAsset(path.c_str());
-    assert(bitmap);
 
     Rect frame = getAbsoluteFrame();
     SkRect rect = SkRect::MakeXYWH(frame.origin.x, frame.origin.y, frame.size.width, frame.size.height);
     auto const &imageBorderMetrics=imageProps.resolveBorderMetrics(component.layoutMetrics);
 
+ /* Draw order 1. Background 2. Image 3. Border*/
     drawBackground(canvas,frame,imageBorderMetrics,imageProps.backgroundColor,imageProps.opacity);
-    canvas->drawBitmapRect(*bitmap, rect, nullptr);
+    RNS_PROFILE_START(drawImage)
+    sk_sp<SkImage> imageData=getImageData(path.c_str());
+    if(imageData) {
+      canvas->drawImageRect(imageData, rect, nullptr);
+    } else {
+      RNS_LOG_ERROR("Draw Image Failed for:" << path);
+    }
+    RNS_PROFILE_END(path.c_str(),drawImage)
+#ifdef RNS_IMAGE_CACHE_USAGE_DEBUG
+      printCacheUsage();
+#endif //RNS_IMAGECACHING_DEBUG
     drawBorder(canvas,frame,imageBorderMetrics,imageProps.backgroundColor,imageProps.opacity);
   }
 }

--- a/ReactSkia/views/common/RSkImageCacheManager.cpp
+++ b/ReactSkia/views/common/RSkImageCacheManager.cpp
@@ -1,0 +1,146 @@
+ /*
+ * Copyright (C) 1994-2021 OpenTV, Inc. and Nagravision S.A.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include <string>
+#include <map>
+#include <iterator>
+
+#include "include/core/SkData.h"
+
+#include "ReactSkia/RSkSurfaceWindow.h"
+#include "ReactSkia/views/common/RSkImageCacheManager.h"
+#include "ReactSkia/utils/RnsLog.h"
+
+using namespace std;
+
+#define SKIA_CPU_IMAGE_CACHE_HWM_LIMIT  SKIA_CPU_IMAGE_CACHE_LIMIT *.95 //95% as High Water mark level
+#define SKIA_GPU_IMAGE_CACHE_HWM_LIMIT  SKIA_CPU_IMAGE_CACHE_LIMIT *.95 //95% as High Water mark level
+#define EVICT_COUNT  2 // Number of entries to be evicted on evictAsNeeded
+
+namespace facebook {
+namespace react {
+
+namespace RSkImageCacheManager{
+   
+namespace {
+  
+  map<size_t, sk_sp<SkImage>> ImageCacheMap;
+  size_t cpuCacheLimit_{0},gpuCacheLimit_{0};
+
+  void setCpuImageCacheLimit(size_t cacheLimit) {
+    SkGraphics::SetResourceCacheTotalByteLimit(cacheLimit);
+    cpuCacheLimit_ = SkGraphics::GetResourceCacheTotalByteLimit();
+  }
+
+#ifdef RNS_SHELL_HAS_GPU_SUPPORT
+  void setGpuImageCacheLimit(size_t cacheLimit) {
+    GrDirectContext* gpuContext = RSkSurfaceWindow::getDirectContext();
+    if(gpuContext) {
+      gpuContext->setResourceCacheLimit(cacheLimit);  
+      gpuCacheLimit_ = gpuContext->getResourceCacheLimit();
+    }
+  }
+#endif
+
+  sk_sp<SkImage> makeImageData(const char *path) {
+    sk_sp<SkData> data = SkData::MakeFromFileName(path);
+    if (!data) {
+      RNS_LOG_ERROR("Unable to make SkData for path :" << path);
+      return nullptr;
+    }
+    return( SkImage::MakeFromEncoded(data ));
+  }
+  
+  bool evictAsNeeded() {
+
+  	size_t cpuCacheUsed{0} , gpuCacheUsed{0};
+    int fOldCount{0}, evictCount{0};
+    map<size_t, sk_sp<SkImage>>::iterator it;
+
+/*Read memory usage on CPU/GU Caches*/
+  #ifdef RNS_SHELL_HAS_GPU_SUPPORT
+    GrDirectContext* gpuContext =RSkSurfaceWindow::getDirectContext();
+    if(gpuContext) {
+      gpuContext->getResourceCacheUsage(&fOldCount, &gpuCacheUsed);       
+    }
+  #endif
+    cpuCacheUsed = SkGraphics::GetResourceCacheTotalBytesUsed();
+    RNS_LOG_DEBUG("CPU CACHE consumed bytes: "<<cpuCacheUsed<< ",, GPU CACHE consumed bytes: "<<gpuCacheUsed);
+
+    /*Evict entry on reaching HWM. This logic to be enchanced based on growing need and clarity.*/
+    for(it = ImageCacheMap.begin();(it != ImageCacheMap.end()) && (evictCount < EVICT_COUNT);) {
+      if((cpuCacheUsed < SKIA_CPU_IMAGE_CACHE_HWM_LIMIT) && ( gpuCacheUsed < SKIA_GPU_IMAGE_CACHE_HWM_LIMIT))
+        break;
+      if((it->second)->unique()) {
+          ImageCacheMap.erase(it++);
+          evictCount++;
+          RNS_LOG_DEBUG("Evicting Entry from RNS Image Hash Map ...");
+      } else {
+          ++it;
+      }
+    }
+    return ((cpuCacheUsed < SKIA_CPU_IMAGE_CACHE_LIMIT) && ( gpuCacheUsed < SKIA_GPU_IMAGE_CACHE_LIMIT));
+  }
+
+}//namespace
+
+sk_sp<SkImage> getImageData(const char *path) {
+
+  hash<string> hashedKey; 
+  sk_sp<SkImage> imageData{nullptr};
+  /*Set Cache limit, if not set before*/
+  if(cpuCacheLimit_ != SKIA_CPU_IMAGE_CACHE_LIMIT) {
+    setCpuImageCacheLimit(SKIA_CPU_IMAGE_CACHE_LIMIT);
+  }
+#ifdef RNS_SHELL_HAS_GPU_SUPPORT
+  if(gpuCacheLimit_ != SKIA_GPU_IMAGE_CACHE_LIMIT) {
+    setGpuImageCacheLimit(SKIA_GPU_IMAGE_CACHE_LIMIT);
+  }
+#endif
+  if(!path) {
+    RNS_LOG_ERROR("Invalid File");
+    return nullptr;
+  }
+ /*first check file entry in hash map, if entry not exist, create imageData*/
+  map<size_t, sk_sp<SkImage>>::iterator it = ImageCacheMap.find(hashedKey(path));
+  imageData= ((it != ImageCacheMap.end()) ? it->second : nullptr);
+  if(!imageData) {
+    imageData = makeImageData(path);
+    /*Add entry to hash map only if the cache mem usage is with in the limit*/
+    if(evictAsNeeded() && imageData) {
+      ImageCacheMap.insert(pair<size_t, sk_sp<SkImage>>(hashedKey(path),imageData));
+      RNS_LOG_DEBUG("New Entry in Map..."<< ImageCacheMap.size()<<" for file :"<<path);
+    } else {
+        RNS_LOG_DEBUG("Mem limit reached or Couldn't create imageData, file is not cached ...");
+    }
+  }
+  return imageData;
+}
+
+#ifdef RNS_IMAGE_CACHE_USAGE_DEBUG
+void printCacheUsage() {
+  size_t cpuUsedMem{0},gpuUsedMem{0};
+  static size_t prevCpuUsedMem{0},prevGpuUsedMem{0};
+  int fOldCount{0};
+
+  cpuUsedMem = SkGraphics::GetResourceCacheTotalBytesUsed(); 
+#ifdef RNS_SHELL_HAS_GPU_SUPPORT
+  GrDirectContext* gpuContext =RSkSurfaceWindow::getDirectContext();
+  if(gpuContext) {
+    gpuContext->getResourceCacheUsage(&fOldCount, &gpuUsedMem);
+    RNS_LOG_INFO("Memory consumed for this run in GPU CACHE:"<<(gpuUsedMem - prevGpuUsedMem));
+    prevGpuUsedMem = gpuUsedMem;
+  }
+#endif
+  RNS_LOG_INFO("Memory consumed for this run in CPU CACHE :"<<(cpuUsedMem - prevCpuUsedMem));
+  prevCpuUsedMem = cpuUsedMem;
+}
+#endif/*RNS_IMAGE_CACHE_USAGE_DEBUG*/
+
+} //RSkImageCacheManager
+
+} // namespace react
+} // namespace facebook

--- a/ReactSkia/views/common/RSkImageCacheManager.cpp
+++ b/ReactSkia/views/common/RSkImageCacheManager.cpp
@@ -4,9 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-#include <string>
-#include <map>
-#include <iterator>
+#include <better/map.h>
 
 #include "include/core/SkData.h"
 
@@ -18,7 +16,7 @@ using namespace std;
 
 #define SKIA_CPU_IMAGE_CACHE_HWM_LIMIT  SKIA_CPU_IMAGE_CACHE_LIMIT *.95 //95% as High Water mark level
 #define SKIA_GPU_IMAGE_CACHE_HWM_LIMIT  SKIA_CPU_IMAGE_CACHE_LIMIT *.95 //95% as High Water mark level
-#define EVICT_COUNT  2 // Number of entries to be evicted on evictAsNeeded
+#define EVICT_COUNT  2 // Max No. of entries to be evicted in single run
 
 namespace facebook {
 namespace react {
@@ -26,26 +24,14 @@ namespace react {
 namespace RSkImageCacheManager{
    
 namespace {
-  
-  map<size_t, sk_sp<SkImage>> ImageCacheMap;
-  size_t cpuCacheLimit_{0},gpuCacheLimit_{0};
 
-  void setCpuImageCacheLimit(size_t cacheLimit) {
-    SkGraphics::SetResourceCacheTotalByteLimit(cacheLimit);
-    cpuCacheLimit_ = SkGraphics::GetResourceCacheTotalByteLimit();
-  }
+  typedef better::map <string, sk_sp<SkImage>> ImageCacheMap;
+  ImageCacheMap imageCache;
+  #define CPU_MEM_ARR_INDEX 0
+  #define GPU_MEM_ARR_INDEX 1
+  std::mutex mutexLock;
 
-#ifdef RNS_SHELL_HAS_GPU_SUPPORT
-  void setGpuImageCacheLimit(size_t cacheLimit) {
-    GrDirectContext* gpuContext = RSkSurfaceWindow::getDirectContext();
-    if(gpuContext) {
-      gpuContext->setResourceCacheLimit(cacheLimit);  
-      gpuCacheLimit_ = gpuContext->getResourceCacheLimit();
-    }
-  }
-#endif
-
-  sk_sp<SkImage> makeImageData(const char *path) {
+  inline sk_sp<SkImage> makeImageData(const char *path) {
     sk_sp<SkData> data = SkData::MakeFromFileName(path);
     if (!data) {
       RNS_LOG_ERROR("Unable to make SkData for path :" << path);
@@ -54,89 +40,97 @@ namespace {
     return( SkImage::MakeFromEncoded(data ));
   }
   
-  bool evictAsNeeded() {
-
-  	size_t cpuCacheUsed{0} , gpuCacheUsed{0};
-    int fOldCount{0}, evictCount{0};
-    map<size_t, sk_sp<SkImage>>::iterator it;
-
-/*Read memory usage on CPU/GU Caches*/
+  inline void getCacheUsage(size_t usageArr[]) {
+    int fOldCount{0};
+    usageArr[CPU_MEM_ARR_INDEX] = SkGraphics::GetResourceCacheTotalBytesUsed();
   #ifdef RNS_SHELL_HAS_GPU_SUPPORT
     GrDirectContext* gpuContext =RSkSurfaceWindow::getDirectContext();
-    if(gpuContext) {
-      gpuContext->getResourceCacheUsage(&fOldCount, &gpuCacheUsed);       
-    }
+    if(gpuContext)
+      gpuContext->getResourceCacheUsage(&fOldCount, &usageArr[GPU_MEM_ARR_INDEX]);
+    else
+      usageArr[GPU_MEM_ARR_INDEX]=0;
   #endif
-    cpuCacheUsed = SkGraphics::GetResourceCacheTotalBytesUsed();
-    RNS_LOG_DEBUG("CPU CACHE consumed bytes: "<<cpuCacheUsed<< ",, GPU CACHE consumed bytes: "<<gpuCacheUsed);
+    RNS_LOG_DEBUG("CPU CACHE consumed bytes: "<<usageArr[CPU_MEM_ARR_INDEX]<< ", GPU CACHE consumed bytes: "<<usageArr[GPU_MEM_ARR_INDEX]);
+  }
 
-    /*Evict entry on reaching HWM. This logic to be enchanced based on growing need and clarity.*/
-    for(it = ImageCacheMap.begin();(it != ImageCacheMap.end()) && (evictCount < EVICT_COUNT);) {
-      if((cpuCacheUsed < SKIA_CPU_IMAGE_CACHE_HWM_LIMIT) && ( gpuCacheUsed < SKIA_GPU_IMAGE_CACHE_HWM_LIMIT))
+  bool evictAsNeeded() {
+
+    int evictCount{0};
+    size_t usageArr[2]={0,0};
+
+    getCacheUsage(usageArr);
+    if ((usageArr[CPU_MEM_ARR_INDEX] < SKIA_CPU_IMAGE_CACHE_HWM_LIMIT) && ( usageArr[GPU_MEM_ARR_INDEX] < SKIA_GPU_IMAGE_CACHE_HWM_LIMIT))
+      return true;
+
+    ImageCacheMap::iterator it=imageCache.begin();
+    while( it != imageCache.end()) {
+      if( evictCount >= EVICT_COUNT)
         break;
       if((it->second)->unique()) {
-          ImageCacheMap.erase(it++);
+          it=imageCache.erase(it);
           evictCount++;
-          RNS_LOG_DEBUG("Evicting Entry from RNS Image Hash Map ...");
       } else {
           ++it;
       }
     }
-    return ((cpuCacheUsed < SKIA_CPU_IMAGE_CACHE_LIMIT) && ( gpuCacheUsed < SKIA_GPU_IMAGE_CACHE_LIMIT));
+    /*As eviction from Skia's cache & RNS cache system  were asynchronous,Ensuring cache memory drained below the Limit is not feasible at this point.
+      So just let to add further, if eviction occured at RNS Level */
+    return (evictCount == EVICT_COUNT);
   }
 
 }//namespace
 
+void configure() {
+  SkGraphics::SetResourceCacheTotalByteLimit(SKIA_CPU_IMAGE_CACHE_LIMIT);
+#ifdef RNS_SHELL_HAS_GPU_SUPPORT
+  GrDirectContext* gpuContext = RSkSurfaceWindow::getDirectContext();
+    if(gpuContext)
+      gpuContext->setResourceCacheLimit(SKIA_GPU_IMAGE_CACHE_LIMIT);
+#endif /*RNS_SHELL_HAS_GPU_SUPPORT*/
+}
+
 sk_sp<SkImage> getImageData(const char *path) {
 
-  hash<string> hashedKey; 
   sk_sp<SkImage> imageData{nullptr};
-  /*Set Cache limit, if not set before*/
-  if(cpuCacheLimit_ != SKIA_CPU_IMAGE_CACHE_LIMIT) {
-    setCpuImageCacheLimit(SKIA_CPU_IMAGE_CACHE_LIMIT);
-  }
-#ifdef RNS_SHELL_HAS_GPU_SUPPORT
-  if(gpuCacheLimit_ != SKIA_GPU_IMAGE_CACHE_LIMIT) {
-    setGpuImageCacheLimit(SKIA_GPU_IMAGE_CACHE_LIMIT);
-  }
-#endif
+
   if(!path) {
     RNS_LOG_ERROR("Invalid File");
     return nullptr;
   }
- /*first check file entry in hash map, if entry not exist, create imageData*/
-  map<size_t, sk_sp<SkImage>>::iterator it = ImageCacheMap.find(hashedKey(path));
-  imageData= ((it != ImageCacheMap.end()) ? it->second : nullptr);
+
+  std::scoped_lock lock(mutexLock);
+
+ /*First to check file entry presence . If not exist, generate imageData*/
+  ImageCacheMap::iterator it = imageCache.find(path);
+  imageData= ((it != imageCache.end()) ? it->second : nullptr);
   if(!imageData) {
     imageData = makeImageData(path);
     /*Add entry to hash map only if the cache mem usage is with in the limit*/
+    /* TO DO: Eviction mechanism to be improved by decouple it from getImageData,
+              through worker thread ....*/
     if(evictAsNeeded() && imageData) {
-      ImageCacheMap.insert(pair<size_t, sk_sp<SkImage>>(hashedKey(path),imageData));
-      RNS_LOG_DEBUG("New Entry in Map..."<< ImageCacheMap.size()<<" for file :"<<path);
+      imageCache.insert(pair<string, sk_sp<SkImage>>(path,imageData));
+      RNS_LOG_DEBUG("New Entry in Map..."<<" file :"<<path);
     } else {
-        RNS_LOG_DEBUG("Mem limit reached or Couldn't create imageData, file is not cached ...");
+        RNS_LOG_DEBUG("Cache Memory limit reached or Couldn't create imageData, So file not cached ...");
     }
+
   }
   return imageData;
 }
 
 #ifdef RNS_IMAGE_CACHE_USAGE_DEBUG
 void printCacheUsage() {
-  size_t cpuUsedMem{0},gpuUsedMem{0};
   static size_t prevCpuUsedMem{0},prevGpuUsedMem{0};
-  int fOldCount{0};
+  size_t usageArr[2]={0,0};
 
-  cpuUsedMem = SkGraphics::GetResourceCacheTotalBytesUsed(); 
+  getCacheUsage(usageArr);
+  RNS_LOG_INFO("Memory consumed for this run in CPU CACHE :"<<(usageArr[CPU_MEM_ARR_INDEX] - prevCpuUsedMem));
+  prevCpuUsedMem = usageArr[CPU_MEM_ARR_INDEX];
 #ifdef RNS_SHELL_HAS_GPU_SUPPORT
-  GrDirectContext* gpuContext =RSkSurfaceWindow::getDirectContext();
-  if(gpuContext) {
-    gpuContext->getResourceCacheUsage(&fOldCount, &gpuUsedMem);
-    RNS_LOG_INFO("Memory consumed for this run in GPU CACHE:"<<(gpuUsedMem - prevGpuUsedMem));
-    prevGpuUsedMem = gpuUsedMem;
-  }
+    RNS_LOG_INFO("Memory consumed for this run in GPU CACHE:"<<(usageArr[GPU_MEM_ARR_INDEX] - prevGpuUsedMem));
+    prevGpuUsedMem = usageArr[GPU_MEM_ARR_INDEX];
 #endif
-  RNS_LOG_INFO("Memory consumed for this run in CPU CACHE :"<<(cpuUsedMem - prevCpuUsedMem));
-  prevCpuUsedMem = cpuUsedMem;
 }
 #endif/*RNS_IMAGE_CACHE_USAGE_DEBUG*/
 

--- a/ReactSkia/views/common/RSkImageCacheManager.h
+++ b/ReactSkia/views/common/RSkImageCacheManager.h
@@ -13,12 +13,13 @@
 #define SKIA_CPU_IMAGE_CACHE_LIMIT  50*1024*1024 // 52,428,800 bytes
 #define SKIA_GPU_IMAGE_CACHE_LIMIT  50*1024*1024 // 52,428,800 bytes
 
+
 namespace facebook {
 namespace react {
 
 namespace RSkImageCacheManager{
-  
-  sk_sp<SkImage> getImageData(const char *path); // Interface to get teh extarcted image Data
+  void configure();
+  sk_sp<SkImage> getImageData(const char *path);
 #ifdef RNS_IMAGE_CACHE_USAGE_DEBUG
   void printCacheUsage();
 #endif

--- a/ReactSkia/views/common/RSkImageCacheManager.h
+++ b/ReactSkia/views/common/RSkImageCacheManager.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 1994-2021 OpenTV, Inc. and Nagravision S.A.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+
+#include "include/core/SkImage.h"
+#include "include/core/SkGraphics.h"
+#include "include/gpu/GrDirectContext.h"
+
+#define SKIA_CPU_IMAGE_CACHE_LIMIT  50*1024*1024 // 52,428,800 bytes
+#define SKIA_GPU_IMAGE_CACHE_LIMIT  50*1024*1024 // 52,428,800 bytes
+
+namespace facebook {
+namespace react {
+
+namespace RSkImageCacheManager{
+  
+  sk_sp<SkImage> getImageData(const char *path); // Interface to get teh extarcted image Data
+#ifdef RNS_IMAGE_CACHE_USAGE_DEBUG
+  void printCacheUsage();
+#endif
+
+} //namespace RSkImageCacheManager
+
+} // namespace react
+} // namespace facebook
+
+
+

--- a/rns_shell/BUILD.gn
+++ b/rns_shell/BUILD.gn
@@ -21,6 +21,9 @@ config("rns_shell_config") {
     if(extra_cppflags != "") {
       defines += string_split(extra_cppflags)
     }
+    if(gl_has_gpu) {
+      defines += [ "RNS_SHELL_HAS_GPU_SUPPORT" ]
+    } 
     if(rns_enable_partial_updates) {
       defines += ["USE_RNS_SHELL_PARTIAL_UPDATES"]
     }
@@ -186,7 +189,6 @@ source_set("rns_shell") {
       } else {
         defines += [ "USE_OPENGL" ]
       }
-      defines += [ "RNS_SHELL_HAS_GPU_SUPPORT" ]
     } else {
         if (gl_display_backend != "x11") {
           defines += [

--- a/rns_shell/compositor/Compositor.cpp
+++ b/rns_shell/compositor/Compositor.cpp
@@ -189,4 +189,10 @@ void Compositor::setViewportSize(const SkRect& viewportSize) {
     commit();
 }
 
+#ifdef RNS_SHELL_HAS_GPU_SUPPORT
+GrDirectContext* Compositor::getDirectContext( ) {
+  return windowContext_ ? windowContext_->directContext() : nullptr;
+}
+#endif
+
 }   // namespace RnsShell

--- a/rns_shell/compositor/Compositor.h
+++ b/rns_shell/compositor/Compositor.h
@@ -39,6 +39,10 @@ public:
     void addDamageRect(SkIRect damage) { if(supportPartialUpdate_ && !damage.isEmpty()) surfaceDamage_.push_back(damage); }
 #endif
 
+#ifdef RNS_SHELL_HAS_GPU_SUPPORT
+    GrDirectContext* getDirectContext(); // interface to expose directcontext of gpu backend
+#endif
+
 private:
 
     void createWindowContext();

--- a/skia/config/SkUserConfig.h
+++ b/skia/config/SkUserConfig.h
@@ -231,7 +231,10 @@ SK_API void SkDebugf_FileLine(const char* file,
 #define SK_FONT_CONFIG_INTERFACE_ONLY_ALLOW_SFNT_FONTS
 
 #define SK_IGNORE_BLURRED_RRECT_OPT
-#define SK_USE_DISCARDABLE_SCALEDIMAGECACHE
+// To be defined for handling custom memory pool
+// On Skia Image caching, enabling it will apply caching constraint on caching count
+// instead on Memory used.
+//#define SK_USE_DISCARDABLE_SCALEDIMAGECACHE
 
 #define SK_ATTR_DEPRECATED          SK_NOTHING_ARG1
 #define GR_GL_CUSTOM_SETUP_HEADER   "GrGLConfig_chrome.h"


### PR DESCRIPTION
    1. Implemented Simple ImageCaching by leveraging image caching mechanism in skia.
    2. Used Skimage in-place of SkBitmap, to make use of Skia's image caching.
    3. No explicit partition used for image caching.
    4. Purging Logic : Unused items will be evicted to maintain cached memory with in the configured limit.
    5. Improvement : Used hard limit for  Caching limit, which needs to be moved to RNS configuration , once defined.
