### PR TITLE
[Bug Fix] On ShadowViewMutation::Update, component does not have updated x&y cordinates

### DIFF
--- a/ReactSkia/components/RSkComponent.cpp
+++ b/ReactSkia/components/RSkComponent.cpp
@@ -62,6 +62,8 @@ void RSkComponent::updateComponentData(const ShadowView &newShadowView , const u
       component_.eventEmitter = newShadowView.eventEmitter;
    if(updateMask & ComponentUpdateMaskLayoutMetrics) {
       component_.layoutMetrics = newShadowView.layoutMetrics;
+      /* TODO : Analyze if this computation can be handled in RNS shell Layer */
+      absOrigin_ =  parent_ ? (parent_->absOrigin_ + component_.layoutMetrics.frame.origin) : component_.layoutMetrics.frame.origin;
 
       Rect frame = component_.layoutMetrics.frame;
       SkIRect frameIRect = SkIRect::MakeXYWH(frame.origin.x, frame.origin.y, frame.size.width, frame.size.height);

--- a/packages/react-native-skia/MutationTest.js
+++ b/packages/react-native-skia/MutationTest.js
@@ -4,13 +4,16 @@ import { View, AppRegistry, Image, Text } from 'react-native';
 
 const SimpleViewApp = React.Node = () => {
   const [color, setColor] = useState('#444');
+  const [width, setWidth] = useState(512);
 
   useEffect(() => {
     const timeout = setTimeout(() => {
       if (color === '#444') {
         setColor('#00ff88');
+	setWidth(256);
       } else {
         setColor('#444');
+	setWidth(512);
       }
     }, 2000);
 
@@ -26,7 +29,7 @@ const SimpleViewApp = React.Node = () => {
                alignItems: 'center',
                backgroundColor: color }}>
       <Image
-        style={{ width: 512, height: 512 }}
+        style={{ width: width, height: 512 }}
         source={require('react-native/Libraries/NewAppScreen/components/logo.png')}
       />
       {color === '#00ff88' && (

--- a/packages/react-native-skia/MutationTest.js
+++ b/packages/react-native-skia/MutationTest.js
@@ -10,10 +10,10 @@ const SimpleViewApp = React.Node = () => {
     const timeout = setTimeout(() => {
       if (color === '#444') {
         setColor('#00ff88');
-	setWidth(256);
+        setWidth(256);
       } else {
         setColor('#444');
-	setWidth(512);
+        setWidth(512);
       }
     }, 2000);
 


### PR DESCRIPTION
In RN, child frame origin is relative with parent origin. So we compute the absolute origin value for child when ShadowViewMutation::Insert instruction. 
This computation is also required to Update instruction.