### PR TITLE
Update text component to use textlayoutmanager passed from ParagraphState

### DIFF
--- a/ReactSkia/components/RSkComponentText.cpp
+++ b/ReactSkia/components/RSkComponentText.cpp
@@ -46,11 +46,10 @@ void RSkComponentParagraph::OnPaint(SkCanvas *canvas) {
   /*    - use parent paragraph builder to add text & push style */
   /*    - draw the paragraph, when we reach the last fragment attachment*/
   if(parent) {
-      parent->expectedAttachmentCount += textLayoutManager_.buildParagraph(
-                                                    data.attributedString,
-                                                    props.paragraphAttributes,
-                                                    true,
-                                                    parent->paraBuilder);
+      parent->expectedAttachmentCount += data.layoutManager->buildParagraph(data.attributedString,
+                                                          props.paragraphAttributes,
+                                                          true,
+                                                          parent->paraBuilder);
       auto paragraph = parent->paraBuilder->Build();
       parent->currentAttachmentCount++;
       if(!parent->expectedAttachmentCount || (parent->expectedAttachmentCount == parent->currentAttachmentCount)) {
@@ -66,9 +65,9 @@ void RSkComponentParagraph::OnPaint(SkCanvas *canvas) {
       }
 
       ParagraphStyle paraStyle;
-      paraBuilder = std::static_pointer_cast<ParagraphBuilder>(std::make_shared<ParagraphBuilderImpl>(paraStyle,textLayoutManager_.collection_));
+      paraBuilder = std::static_pointer_cast<ParagraphBuilder>(std::make_shared<ParagraphBuilderImpl>(paraStyle,data.layoutManager->collection_));
 
-      expectedAttachmentCount = textLayoutManager_.buildParagraph(data.attributedString, props.paragraphAttributes, true, paraBuilder);
+      expectedAttachmentCount = data.layoutManager->buildParagraph(data.attributedString, props.paragraphAttributes, true, paraBuilder);
       currentAttachmentCount = 0;
       auto paragraph = paraBuilder->Build();
 

--- a/ReactSkia/components/RSkComponentText.h
+++ b/ReactSkia/components/RSkComponentText.h
@@ -60,7 +60,6 @@ class RSkComponentParagraph final : public RSkComponent {
      return nullptr;
   }
 
-  RSkTextLayoutManager textLayoutManager_;
 };
 
 } // namespace react

--- a/build/secondary/third_party/glog/BUILD.gn
+++ b/build/secondary/third_party/glog/BUILD.gn
@@ -18,6 +18,7 @@ component("glog") {
   cflags_cc = [
     "-Wno-header-hygiene",
     "-Wno-c++98-compat-extra-semi",
+    "-Wno-unused-result",
   ]
 
   configs -= [ "//build/config/gcc:symbol_visibility_hidden" ]


### PR DESCRIPTION
1. Use shared textlayoutmanager instead of having seperate textlayoutmanager for every text component.
Thus we use single instance of font collection manager, which would be one-time building.
This reduces the layout time.

2. Resolve the glog error 
Build RNS with "is_debug=false" to enable optimization.
disabling this flag, gives error in glog raw_logging.cc file with "unused-result" error. So configuring glog build with "Wno-unused-result" flag to avoid this error in glog thirdparty code.
