### PR TITLE
Added support for handling absolute origin in RNS SHELL

### DIFF
--- a/ReactSkia/MountingManager.cpp
+++ b/ReactSkia/MountingManager.cpp
@@ -160,23 +160,19 @@ void MountingManager::UpdateMountInstruction(
   auto &newChildShadowView = mutation.newChildShadowView;
   uint32_t updateMask = ComponentUpdateMaskNone;
   std::shared_ptr<RSkComponent> newChildComponent = GetComponent(mutation.newChildShadowView);
-  if(newChildComponent)
-  {
-       if(oldChildShadowView.props != newChildShadowView.props)
-           updateMask |= ComponentUpdateMaskProps;
-       if(oldChildShadowView.state != newChildShadowView.state)
-           updateMask |= ComponentUpdateMaskState;
-       if(oldChildShadowView.eventEmitter != newChildShadowView.eventEmitter)
-           updateMask |= ComponentUpdateMaskEventEmitter;
-       if(oldChildShadowView.layoutMetrics != newChildShadowView.layoutMetrics)
-           updateMask |= ComponentUpdateMaskLayoutMetrics;
+  if(newChildComponent) {
+    if(oldChildShadowView.props != newChildShadowView.props)
+      updateMask |= ComponentUpdateMaskProps;
+    if(oldChildShadowView.state != newChildShadowView.state)
+      updateMask |= ComponentUpdateMaskState;
+    if(oldChildShadowView.eventEmitter != newChildShadowView.eventEmitter)
+      updateMask |= ComponentUpdateMaskEventEmitter;
+    if(oldChildShadowView.layoutMetrics != newChildShadowView.layoutMetrics)
+      updateMask |= ComponentUpdateMaskLayoutMetrics;
 
-       if(updateMask != ComponentUpdateMaskNone) {
-           newChildComponent->updateComponentData(mutation.newChildShadowView,updateMask,false);
-       }
-#if USE(RNS_SHELL_PARTIAL_UPDATES)
-       surface_->compositor()->addDamageRect(newChildComponent->layer().get()->getFrame());
-#endif
+    if(updateMask != ComponentUpdateMaskNone) {
+      newChildComponent->updateComponentData(mutation.newChildShadowView,updateMask,false);
+    }
   }
 }
 

--- a/ReactSkia/components/RSkComponent.cpp
+++ b/ReactSkia/components/RSkComponent.cpp
@@ -31,7 +31,7 @@ void RSkComponent::onPaint(SkCanvas* canvas) {
 sk_sp<SkPicture> RSkComponent::getPicture() {
 
   SkPictureRecorder recorder;
-  auto frame = getAbsoluteFrame();
+  auto frame = component_.layoutMetrics.frame;
 
   auto *canvas = recorder.beginRecording(SkRect::MakeXYWH(0, 0, frame.size.width, frame.size.height));
 
@@ -46,13 +46,14 @@ sk_sp<SkPicture> RSkComponent::getPicture() {
 }
 
 void RSkComponent::requiresLayer(const ShadowView &shadowView) {
-    RNS_LOG_TODO("Need to come up with rules to decide wheather we need to create picture layer, texture layer etc");
+    // Need to come up with rules to decide wheather we need to create picture layer, texture layer etc"
     // Text components paragraph builder is not compatabile with Picture layer,so use default layer
     if(strcmp(component_.componentName,"Paragraph") == 0)
         layer_ = this->shared_from_this();
     else
         layer_ = RnsShell::Layer::Create(RnsShell::LAYER_TYPE_PICTURE);
 }
+
 void RSkComponent::updateProps(const ShadowView &newShadowView,bool forceUpdate) {
 
    auto const &newviewProps = *std::static_pointer_cast<ViewProps const>(newShadowView.props);
@@ -121,27 +122,37 @@ void RSkComponent::updateProps(const ShadowView &newShadowView,bool forceUpdate)
 
 void RSkComponent::updateComponentData(const ShadowView &newShadowView,const uint32_t updateMask,bool forceUpdate) {
 
+   RNS_LOG_ASSERT((layer_ && layer_.get()), "Layer Object cannot be null");
+   RNS_LOG_DEBUG("->Update " << component_.componentName << " layer(" << layer_->layerId() << ")");
+
    if(updateMask & ComponentUpdateMaskProps) {
+      RNS_LOG_DEBUG("\tUpdate Property");
       updateProps(newShadowView,forceUpdate);
       component_.props = newShadowView.props;
    }
-   if(updateMask & ComponentUpdateMaskState)
+   if(updateMask & ComponentUpdateMaskState){
+      RNS_LOG_DEBUG("\tUpdate State");
       component_.state = newShadowView.state;
-   if(updateMask & ComponentUpdateMaskEventEmitter)
+   }
+   if(updateMask & ComponentUpdateMaskEventEmitter){
+      RNS_LOG_DEBUG("\tUpdate Emitter");
       component_.eventEmitter = newShadowView.eventEmitter;
+   }
    if(updateMask & ComponentUpdateMaskLayoutMetrics) {
+      RNS_LOG_DEBUG("\tUpdate Layout");
       component_.layoutMetrics = newShadowView.layoutMetrics;
-      /* TODO : Analyze if this computation can be handled in RNS shell Layer */
-      absOrigin_ =  parent_ ? (parent_->absOrigin_ + component_.layoutMetrics.frame.origin) : component_.layoutMetrics.frame.origin;
 
       Rect frame = component_.layoutMetrics.frame;
       SkIRect frameIRect = SkIRect::MakeXYWH(frame.origin.x, frame.origin.y, frame.size.width, frame.size.height);
       if(layer() && layer().get())
-        layer().get()->setFrame(frameIRect);
+        layer_->setFrame(frameIRect);
    }
 
-   if(layer_ && layer_->type() == RnsShell::LAYER_TYPE_PICTURE) {
-     RNS_PROFILE_API_OFF(component_.componentName << " getPicture :", static_cast<RnsShell::PictureLayer*>(layer_.get())->setPicture(getPicture()));
+   if(layer_ && layer_.get()) {
+     layer_->invalidate();
+     if(layer_->type() == RnsShell::LAYER_TYPE_PICTURE) {
+       RNS_PROFILE_API_OFF(component_.componentName << " getPicture :", static_cast<RnsShell::PictureLayer*>(layer_.get())->setPicture(getPicture()));
+     }
    }
 }
 
@@ -151,12 +162,10 @@ void RSkComponent::mountChildComponent(
 
     if(newChildComponent) {
         newChildComponent->parent_ = this;
-        newChildComponent->absOrigin_ =  absOrigin_ + newChildComponent->component_.layoutMetrics.frame.origin;
+        RNS_LOG_ASSERT((this->layer_ && newChildComponent->layer_), "Layer Object cannot be null");
+        if(this->layer_)
+            this->layer_->insertChild(newChildComponent->layer_, index);
     }
-
-    RNS_LOG_ASSERT((this->layer_ && newChildComponent->layer_), "Layer Object cannot be null");
-    if(this->layer_)
-        this->layer_->insertChild(newChildComponent->layer_, index);
 }
 
 void RSkComponent::unmountChildComponent(
@@ -170,7 +179,7 @@ void RSkComponent::unmountChildComponent(
 
     RNS_LOG_ASSERT((this->layer_ && oldChildComponent->layer_), "Layer Object cannot be null");
     if(this->layer_)
-        this->layer_->removeChild(oldChildComponent->layer_, index);
+        this->layer_->removeChild(oldChildComponent->layer_.get(), index);
 }
 
 } // namespace react

--- a/ReactSkia/components/RSkComponent.h
+++ b/ReactSkia/components/RSkComponent.h
@@ -69,10 +69,9 @@ class RSkComponent : public RnsShell::Layer, public std::enable_shared_from_this
     const int index);
 
   virtual void updateComponentData(const ShadowView &newShadowView , const uint32_t updateMask , bool forceUpdate);
-  Component getComponentData() { return component_;};
-  Rect getAbsoluteFrame(){return Rect{absOrigin_,component_.layoutMetrics.frame.size} ;};
+  Component getComponentData() { return component_;}
   std::shared_ptr<RnsShell::Layer> layer() { return layer_; }
-
+  const SkIRect& getLayerAbsoluteFrame(){ return(layer_->absoluteFrame());}
   void requiresLayer(const ShadowView &shadowView);
 
   RSkComponent *getParent() {return parent_; };

--- a/ReactSkia/components/RSkComponentImage.cpp
+++ b/ReactSkia/components/RSkComponentImage.cpp
@@ -64,7 +64,7 @@ void RSkComponentImage::OnPaint(
     auto bitmap = GetAsset(path.c_str());
     assert(bitmap);
 
-    Rect frame = getAbsoluteFrame();
+    Rect frame = component.layoutMetrics.frame;
     SkRect rect = SkRect::MakeXYWH(frame.origin.x, frame.origin.y, frame.size.width, frame.size.height);
     auto const &imageBorderMetrics=imageProps.resolveBorderMetrics(component.layoutMetrics);
 

--- a/ReactSkia/components/RSkComponentText.cpp
+++ b/ReactSkia/components/RSkComponentText.cpp
@@ -61,7 +61,7 @@ void RSkComponentParagraph::OnPaint(SkCanvas *canvas) {
       auto paragraph = parent->paraBuilder->Build();
       parent->currentAttachmentCount++;
       if(!parent->expectedAttachmentCount || (parent->expectedAttachmentCount == parent->currentAttachmentCount)) {
-            auto frame = parent->getAbsoluteFrame();
+            auto frame = parent->getComponentData().layoutMetrics.frame;
             paragraph->layout(frame.size.width);
             paragraph->paint(canvas, frame.origin.x, frame.origin.y);
       }
@@ -81,7 +81,7 @@ void RSkComponentParagraph::OnPaint(SkCanvas *canvas) {
 
       /* If the count is 0,means we have no fragment attachments.So paint right away*/
       if(!expectedAttachmentCount) {
-          auto frame = getAbsoluteFrame();
+          auto frame = component.layoutMetrics.frame;
           paragraph->layout(frame.size.width);
           paragraph->paint(canvas, frame.origin.x, frame.origin.y);
       }

--- a/ReactSkia/components/RSkComponentView.cpp
+++ b/ReactSkia/components/RSkComponentView.cpp
@@ -16,7 +16,7 @@ void RSkComponentView::OnPaint(SkCanvas *canvas) {
   auto const &viewProps = *std::static_pointer_cast<ViewProps const>(component.props);
   /* apply view style props */
   auto borderMetrics=viewProps.resolveBorderMetrics(component.layoutMetrics);
-  Rect frame = getAbsoluteFrame();
+  Rect frame = component.layoutMetrics.frame;
   /*Retrieve Shadow Props*/
   ShadowMetrics shadowMetrics{};
   shadowMetrics.shadowColor=viewProps.shadowColor;

--- a/build/secondary/folly/BUILD.gn
+++ b/build/secondary/folly/BUILD.gn
@@ -4,11 +4,16 @@ config("folly_config") {
   defines = [
     "FOLLY_NO_CONFIG=1",
     "FOLLY_HAVE_CLOCK_GETTIME=1",
-    # "FOLLY_HAVE_MEMRCHR=1",
     "FOLLY_USE_LIBCPP=1",
     "FOLLY_MOBILE=1",
     "FOLLY_HAVE_PTHREAD=1",
   ]
+
+  if (is_linux) {
+    defines += [
+      "FOLLY_HAVE_MEMRCHR=1",
+    ]
+  }
 }
 
 group("folly") {

--- a/rns_shell/compositor/layers/Layer.cpp
+++ b/rns_shell/compositor/layers/Layer.cpp
@@ -11,6 +11,16 @@
 
 namespace RnsShell {
 
+#if USE(RNS_SHELL_PARTIAL_UPDATES)
+static inline void addDamgeRect(PaintContext& context, SkIRect dirtyAbsFrameRect) {
+    // TODO Walk through the dirtyRect vector and
+    // 1. If new dirty rect contains inside any pf existing dirtyRect then ignore
+    // 2. If new dirty rect entirely covers any of existing dirtyRect then remove them from vector and add the new one
+
+    context.damageRect.push_back(dirtyAbsFrameRect);
+}
+#endif
+
 SharedLayer Layer::Create(LayerType type) {
     switch(type) {
         case LAYER_TYPE_PICTURE:
@@ -36,8 +46,10 @@ Layer::Layer(LayerType type)
     , parent_(nullptr)
     , type_(type)
     , frame_(SkIRect::MakeEmpty())
-    , anchorPosition_(SkPoint::Make(0,0)) {
-    RNS_LOG_INFO("Layer Constructed(" << this << ") with ID : " << layerId_);
+    , absFrame_(SkIRect::MakeEmpty())
+    , anchorPosition_(SkPoint::Make(0,0))
+    , invalidateMask_(LayerInvalidateAll) {
+    RNS_LOG_DEBUG("Layer Constructed(" << this << ") with ID : " << layerId_);
 }
 
 Layer* Layer::rootLayer() {
@@ -52,10 +64,12 @@ void Layer::appendChild(SharedLayer child) {
 }
 
 void Layer::insertChild(SharedLayer child, size_t index) {
-    // TODO
-    // Add sanity checks
-    // Check if child already has a parent, and remove it if so
-    RNS_LOG_TODO("Check if child already has a parent, if so then first remove it");
+    if(!child || !child.get()) {
+        RNS_LOG_ERROR("Invalid child node passed");
+        return;
+    }
+
+    child->removeFromParent();
     child->setParent(this);
 
     index = std::min(index, children_.size());
@@ -63,18 +77,82 @@ void Layer::insertChild(SharedLayer child, size_t index) {
     children_.insert(children_.begin() + index, child);
 }
 
-void Layer::removeChild(SharedLayer child, size_t index) {
+void Layer::removeChild(Layer *child, size_t index) {
     if(index >= children_.size()) {
         RNS_LOG_ERROR("Invalid index passed for remove");
         return;
     }
     child->setParent(nullptr);
 
-    RNS_LOG_DEBUG("Remove Child(" << child.get()->layerId() << ") at index : " << index << " from parent : " << layerId_);
+    RNS_LOG_DEBUG("Remove Child(" << child->layerId() << ") at index : " << index << " from parent : " << layerId_);
     children_.erase(children_.begin() + index);
 }
 
-void Layer::prePaint(PaintContext& context) {
+void Layer::removeChild(Layer *child) {
+    size_t index = 0;
+    for (auto iter = children_.begin(); iter != children_.end(); ++iter, index++) {
+        if (iter->get() != child)
+            continue;
+        removeChild(child, index);
+        return;
+    }
+}
+
+void Layer::removeFromParent() {
+  if (parent_)
+    parent_->removeChild(this);
+}
+
+void Layer::preRoll(PaintContext& context, bool forceLayout) {
+    // Layer Layout has changed or parent has forced Layout change for child. Need to recalculate absolute frame and update absFrame_
+    if(forceLayout || (invalidateMask_ & LayerLayoutInvalidate)) {
+        // Adjust absolute position
+        //TODO Once we have skia transform matrix, need to first update frame_ i.e before calculating newAbsFrame
+        // layer_->setFrame( trnsfromed x, y width hight
+        int frameAbsX = frame_.x(), frameAbsY = frame_.y();
+        if(parent_) {
+            frameAbsX += parent_->absFrame_.x();
+            frameAbsY += parent_->absFrame_.y();
+        }
+
+        SkIRect newAbsFrame = SkIRect::MakeXYWH(frameAbsX, frameAbsY, frame_.width(), frame_.height());
+#if USE(RNS_SHELL_PARTIAL_UPDATES)
+        if((invalidateMask_ & LayerLayoutInvalidate)) {
+            // Add previous frame to damage rect only if layer layout was invalidated and new layout is different from old layout
+            if(context.supportPartialUpdate && (invalidateMask_ & LayerLayoutInvalidate)) {
+                if(absFrame_.isEmpty() != true && newAbsFrame.contains(absFrame_) != true ) {
+                    addDamgeRect(context, absFrame_); // Previous frame rect
+                    RNS_LOG_DEBUG("New frame layout is different from previous frame. Add to damage rect..");
+                }
+            }
+            RNS_LOG_DEBUG("PreRoll Layer(ID:" << layerId_ << ", ParentID:" << (parent_ ? parent_->layerId() : -1) <<
+                ") Frame [" << frame_.x() << "," << frame_.y() << "," << frame_.width() << "," << frame_.height() <<
+                "], AbsFrame(Prev,New) ([" << absFrame_.x() << "," << absFrame_.y() << "," << absFrame_.width() << "," << absFrame_.height() << "]" <<
+                " - [" << newAbsFrame.x() << "," << newAbsFrame.y() << "," << newAbsFrame.width() << "," << newAbsFrame.height() << "])");
+        }
+#endif
+        absFrame_ = newAbsFrame; // Save new absFrame
+    }
+
+#if USE(RNS_SHELL_PARTIAL_UPDATES)
+    if(invalidateMask_ != LayerInvalidateNone) {// As long as there is some invalidation , it creates a dirty rect.
+        RNS_LOG_DEBUG("AddDamage Layer(ID:" << layerId_ <<
+            ") AbsFrame[" << absFrame_.x() << "," << absFrame_.y() << "," << absFrame_.width() << "," << absFrame_.height() << "]");
+        addDamgeRect(context, absFrame_); // Previous frame rect
+    }
+#endif
+}
+
+void Layer::prePaint(PaintContext& context, bool forceLayout) {
+    //Adjust absolute Layout frame and dirty rects
+    bool forceChildrenLayout = (forceLayout || (invalidateMask_ & LayerLayoutInvalidate));
+    preRoll(context, forceLayout);
+    invalidateMask_ = LayerInvalidateNone;
+
+    // prePaint children recursively
+    for (auto& layer : children()) {
+        layer->prePaint(context, forceChildrenLayout);
+    }
 }
 
 void Layer::paintSelf(PaintContext& context) {
@@ -92,10 +170,11 @@ void Layer::paintSelf(PaintContext& context) {
 
 void Layer::paint(PaintContext& context) {
     RNS_LOG_DEBUG("Layer (" << layerId_ << ") has " << children_.size() << " childrens");
+
     SkAutoCanvasRestore save(context.canvas, true); // Save current clip and matrix state.
 
-    // TODO Concat matrix
     paintSelf(context); // First paint self and then children if any
+    context.canvas->translate(frame_.x(), frame_.y());
 
     if(masksToBounds_) { // Need to clip children.
         SkRect intRect = SkRect::Make(frame_);
@@ -111,30 +190,40 @@ void Layer::paint(PaintContext& context) {
     }
 }
 
+bool Layer::hasAncestor(const Layer* ancestor) const {
+    for (const Layer* layer = parent(); layer; layer = layer->parent()) {
+        if (layer == ancestor)
+            return true;
+    }
+    return false;
+}
+
 void Layer::setParent(Layer* layer) {
-    // TODO add checks
-    RNS_LOG_TODO("Add checks");
+    if(layer && layer->hasAncestor(this)) {
+        RNS_LOG_WARN("Child Layer cant be ancestor :)");
+        return;
+    }
     parent_ = layer;
 }
 
 bool Layer::needsPainting(PaintContext& context) {
-
     if (frame_.isEmpty() || isHidden_) { // If layer is hidden or layers paint bounds is empty then skip paint
       RNS_LOG_TRACE(this << " Layer (" << layerId_ << ") Bounds empty or hidden");
       return false;
     }
 
-    if(context.damageRect->size() == 0) // No damage rect set, so need to paint the layer
+    if(context.damageRect.size() == 0) // No damage rect set, so need to paint the layer
         return true;
 
     // As long as paintBounds interset with one of the dirty rect, we will need repainting.
     SkIRect dummy;
-    for (auto& dirtRect : *context.damageRect) {
-        if(dummy.intersect(frame_, dirtRect)) // this layer intersects with one of the dirty rect, so needs repainting
+    for (auto& dirtRect : context.damageRect) {
+        if(dummy.intersect(absFrame_, dirtRect)) { // this layer intersects with one of the dirty rect, so needs repainting
             return true;
+        }
     }
 
-    RNS_LOG_TRACE("Skip Layer (" << layerId_ << ")");
+    RNS_LOG_TRACE("Skip Layer (" << layerId_ << ") Frame [" << frame_.x() << "," << frame_.y() << "," << frame_.width() << "," << frame_.height() << "]");
     return false;
 }
 

--- a/rns_shell/compositor/layers/PictureLayer.h
+++ b/rns_shell/compositor/layers/PictureLayer.h
@@ -25,7 +25,7 @@ public:
 
     SkPicture* picture() const { return picture_.get(); }
     virtual void paintSelf(PaintContext& context) override;
-    void prePaint(PaintContext& context) override;
+    void prePaint(PaintContext& context, bool forceChildrenLayout = false) override;
     void paint(PaintContext& context) override;
 
     void setPicture(sk_sp<SkPicture> picture) { picture_ = picture; }


### PR DESCRIPTION
* Move Absolute Origin Calculation and Marking Dirty region logic to RNS Shell.
   Now Abs origin will be calculated after all the mutation is processed.
   Nested Children layout issue will be resolved with this.
* Implemented multiple helper functions in Layer Classes from TODO list.
* Fix Folly MEMRCHR compilation issue on newer Ubuntu OS