### PR TITLE
Add support for RN platform configuration

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -10,11 +10,12 @@ gclient_gn_args = [
   'checkout_oculus_sdk',
   'checkout_openxr',
   'mac_xcode_version',
+  'react_native_target',
 ]
 
 vars = {
-  'react_native_revision': 'e599d6c5d338c1b4d1a0d988e0d9ff83c179fb54',
-
+  'react_native_default_revision': 'deb66012fe550d536420931e47f5573e798e048a',
+  'react_native_tvos_revision': 'tvos-v0.64.2',
   'skia_revision': 'chrome/m86',
 
   # Note this revision should be updated with
@@ -28,7 +29,8 @@ vars = {
   'libcxxabi_revision':    '196ba1aaa8ac285d94f4ea8d9836390a45360533',
   'libunwind_revision':    'd999d54f4bca789543a2eb6c995af2d9b5a1f3ed',
 
-  'react_native_git': 'https://github.com/facebook/react-native.git',
+  'react_native_default_git': 'https://github.com/Kudo/react-native.git',
+  'react_native_tvos_git': 'https://github.com/nagra-opentv/react-native-tvos.git',
   'chromium_git': 'https://chromium.googlesource.com',
   'skia_git': 'https://skia.googlesource.com',
   'fuchsia_git': 'https://fuchsia.googlesource.com',
@@ -43,12 +45,12 @@ vars = {
   'checkout_oculus_sdk' : False,
   'checkout_openxr' : False,
   'mac_xcode_version': 'default',
+
+  'react_native_target':'default'
 }
 
 deps = {
-  # 'src/react-native'                      : Var('react_native_git') + '@' + Var('react_native_revision'),
-  # react-native patch to fix cxx textlayoutmanager build break
-  'src/react-native'                      : 'https://github.com/Kudo/react-native.git' + '@' + 'deb66012fe550d536420931e47f5573e798e048a',
+  'src/react-native'                      : Var('react_native_'+Var('react_native_target')+'_git') + '@' + Var('react_native_'+Var('react_native_target')+'_revision'),
 
   # 'src/folly'                             : 'https://github.com/facebook/folly.git' + '@' + 'v2020.01.13.00',
   # folly custom patch to support boringssl, might not be necessary after we replace folly/async with flutter/fml

--- a/DEPS
+++ b/DEPS
@@ -10,10 +10,12 @@ gclient_gn_args = [
   'checkout_oculus_sdk',
   'checkout_openxr',
   'mac_xcode_version',
-  'react_native_target',
+  'react_native_platform',
 ]
 
 vars = {
+  "react_native_revision": "react_native_tvos_revision",
+  "react_native_git": "react_native_tvos_git",
   'react_native_default_revision': 'deb66012fe550d536420931e47f5573e798e048a',
   'react_native_tvos_revision': 'tvos-v0.64.2',
   'skia_revision': 'chrome/m86',
@@ -46,11 +48,13 @@ vars = {
   'checkout_openxr' : False,
   'mac_xcode_version': 'default',
 
-  'react_native_target':'default'
+  'react_native_platform':'default',
+  'react_native_platform_git':'react_native_default_git',
+  'react_native_platform_revision':'react_native_default_revision',
 }
 
 deps = {
-  'src/react-native'                      : Var('react_native_'+Var('react_native_target')+'_git') + '@' + Var('react_native_'+Var('react_native_target')+'_revision'),
+  'src/react-native'                      : Var(Var('react_native_platform_git')) + '@' + Var(Var('react_native_platform_revision')),
 
   # 'src/folly'                             : 'https://github.com/facebook/folly.git' + '@' + 'v2020.01.13.00',
   # folly custom patch to support boringssl, might not be necessary after we replace folly/async with flutter/fml

--- a/ReactSkia/BUILD.gn
+++ b/ReactSkia/BUILD.gn
@@ -11,10 +11,7 @@ config("ReactSkia_config") {
   if(rns_enable_api_profiling) {
     defines += ["RNS_ENABLE_API_PERF"]
   }
-  if( react_native_target == "default") {
-     print(" ** React Native Target :  Default **")
-  } else if( react_native_target == "tvos") {
-     print(" ** React Native Target :  TVOS **")
+  if( react_native_platform == "tvos") {
      defines += ["TARGET_OS_TV=1"]
   }
 }

--- a/ReactSkia/BUILD.gn
+++ b/ReactSkia/BUILD.gn
@@ -5,10 +5,17 @@ declare_args() {
   rns_enable_api_profiling = false
 }
 
+import("//build/config/gclient_args.gni")
 config("ReactSkia_config") {
   defines = []
   if(rns_enable_api_profiling) {
     defines += ["RNS_ENABLE_API_PERF"]
+  }
+  if( react_native_target == "default") {
+     print(" ** React Native Target :  Default **")
+  } else if( react_native_target == "tvos") {
+     print(" ** React Native Target :  TVOS **")
+     defines += ["TARGET_OS_TV=1"]
   }
 }
 

--- a/build/config/gclient_args.gni
+++ b/build/config/gclient_args.gni
@@ -9,4 +9,4 @@ checkout_nacl = false
 checkout_oculus_sdk = false
 checkout_openxr = false
 mac_xcode_version = "default"
-react_native_target = "default"
+react_native_platform = "default"

--- a/build/config/gclient_args.gni
+++ b/build/config/gclient_args.gni
@@ -9,3 +9,4 @@ checkout_nacl = false
 checkout_oculus_sdk = false
 checkout_openxr = false
 mac_xcode_version = "default"
+react_native_target = "default"

--- a/build/secondary/react-native/ReactCommon/react/renderer/components/view/BUILD.gn
+++ b/build/secondary/react-native/ReactCommon/react/renderer/components/view/BUILD.gn
@@ -12,7 +12,11 @@ rn_cxx_component("view") {
     "YogaLayoutableShadowNode.cpp",
     "YogaStylableProps.cpp",
   ]
-
+  if( react_native_platform == "tvos") {
+    sources += [
+      "TVViewProps.cpp",
+    ]
+  }
   defines = [
     "LOG_TAG=ReactNative",
   ]

--- a/build/secondary/react-native/common.gni
+++ b/build/secondary/react-native/common.gni
@@ -1,3 +1,4 @@
+import("//build/config/gclient_args.gni")
 template("rn_cxx_component") {
   with_exceptions = false
   if (defined(invoker.with_exceptions)) {

--- a/packages/react-native-skia/package.json
+++ b/packages/react-native-skia/package.json
@@ -10,6 +10,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "react-native": "1000.0.0"
+    "react-native": "file:../../react-native"
   }
 }


### PR DESCRIPTION
Add support to configure React Native platform configuration. 
This will enable us to switch between React Native projects, currently supporting default and tvos platforms.

By default configured to use "default" RN project platform.
Steps for switching to RN TVOS project or vice versa  

- In existing workspace, delete react-native and node_modules folder
- gclient setdep --var=react_native_platform=tvos
- gclient setdep --var=react_native_platform_revision=react_native_tvos_revision
- gclient setdep --var=react_native_platform_git=react_native_tvos_git
- gclient sync --with_branch_heads
- yarn 
- Build commands  