### PR TITLE
Added Render Delegate & LayerTreeHost Support in RNS Shell And Restructred the code

### DIFF
--- a/ReactSkia/MountingManager.h
+++ b/ReactSkia/MountingManager.h
@@ -4,15 +4,22 @@
 #include "react/renderer/scheduler/SchedulerDelegate.h"
 #include "ReactSkia/ComponentViewRegistry.h"
 
+namespace RnsShell {
+  class RendererDelegate;
+}
+
 namespace facebook {
 namespace react {
 
+using namespace RnsShell;
+
 class ComponentViewRegistry;
 class RSkSurfaceWindow;
+class ReactSkiaApp;
 
 class MountingManager : public SchedulerDelegate {
  public:
-  MountingManager(ComponentViewRegistry *componentViewRegistry);
+  MountingManager(ComponentViewRegistry *componentViewRegistry, RendererDelegate &rendererDelegate);
   MountingManager(MountingManager &&) = default;
 
   void BindSurface(RSkSurfaceWindow *surface);
@@ -83,6 +90,7 @@ class MountingManager : public SchedulerDelegate {
 
 
  private:
+  RendererDelegate& nativeRenderDelegate_;
   ComponentViewRegistry *componentViewRegistry_;
   RSkSurfaceWindow *surface_;
 };

--- a/ReactSkia/RNInstance.cpp
+++ b/ReactSkia/RNInstance.cpp
@@ -19,6 +19,7 @@
 #endif
 #include "ReactSkia/utils/RnsLog.h"
 #include "ReactSkia/utils/AppLog.h"
+#include "ReactSkia/views/common/RSkConversion.h"
 
 #include "ReactCommon/TurboModuleBinding.h"
 #include "cxxreact/JSBigString.h"
@@ -35,6 +36,8 @@
 #include "react/utils/ContextContainer.h"
 
 #include <folly/io/async/ScopedEventBaseThread.h>
+
+#include "rns_shell/compositor/RendererDelegate.h"
 
 namespace facebook {
 namespace react {
@@ -86,38 +89,55 @@ class MessageQueueThreadImpl : public MessageQueueThread {
   folly::ScopedEventBaseThread thread_;
 };
 
-RNInstance::RNInstance() {
+static inline LayoutConstraints RSkGetLayoutConstraintsForSize(SkSize minimumSize, SkSize maximumSize) {
+  return {
+      .minimumSize = RCTSizeFromSkSize(minimumSize),
+      .maximumSize = RCTSizeFromSkSize(maximumSize),
+      .layoutDirection = facebook::react::LayoutDirection::LeftToRight, // TODO Hardcode for now and later based on some condition like IOS ??
+  };
+}
+
+static inline LayoutContext RSkGetLayoutContext(SkPoint viewportOffset) {
+  return {.pointScaleFactor = 1.0,
+          .swapLeftAndRightInRTL = false,
+          .fontSizeMultiplier = 1.0,
+          .viewportOffset = RCTPointFromSkPoint(viewportOffset)};
+}
+
+RNInstance::RNInstance(RendererDelegate &rendererDelegate) {
   InitializeJSCore();
   RegisterComponents();
-  InitializeFabric();
+  InitializeFabric(rendererDelegate);
 }
 
 RNInstance::~RNInstance() {}
 
-void RNInstance::Start(RSkSurfaceWindow *surface) {
+void RNInstance::Start(RSkSurfaceWindow *surface, RendererDelegate &rendererDelegate) {
   mountingManager_->BindSurface(surface);
-  SurfaceId surfaceId = 1;
+
+  LayoutContext layoutContext = RSkGetLayoutContext(surface->viewportOffset);
+  LayoutConstraints layoutConstraints = RSkGetLayoutConstraintsForSize(surface->minimumSize, surface->maximumSize);
+
   fabricScheduler_->startSurface(
-      surfaceId,
-      "SimpleViewApp",
-      folly::dynamic::object(),
-      surface->GetLayoutConstraints(),
-      {}, // layoutContext,
+      surface->surfaceId,
+      surface->moduleName,
+      surface->properties,
+      layoutConstraints,
+      layoutContext,
       {} // mountingOverrideDelegate
   );
-  fabricScheduler_->renderTemplateToSurface(surfaceId, {});
+  fabricScheduler_->renderTemplateToSurface(surface->surfaceId, {});
 
   // NOTE(kudo): Does adding RootView here make sense !?
   auto *provider = componentViewRegistry_->GetProvider(RootComponentName);
   auto component = provider->CreateComponent({});
-  component.get()->requiresLayer({});
-  if(component)
-    surface->compositor()->setRootLayer(component->layer() ? component->layer() : component);
+  component->requiresLayer({}, rendererDelegate);
+  RNS_LOG_ASSERT(component->layer(), "Layer Cannot Be Null");
+  rendererDelegate.setRootLayer(component->layer());
 }
 
-void RNInstance::Stop() {
-  SurfaceId surfaceId = 1;
-  fabricScheduler_->stopSurface(surfaceId);
+void RNInstance::Stop(RSkSurfaceWindow *surface) {
+  fabricScheduler_->stopSurface(surface->surfaceId);
 }
 
 void RNInstance::InitializeJSCore() {
@@ -149,7 +169,7 @@ void RNInstance::InitializeJSCore() {
   }
 }
 
-void RNInstance::InitializeFabric() {
+void RNInstance::InitializeFabric(RendererDelegate &rendererDelegate) {
   facebook::react::ContextContainer::Shared contextContainer =
       std::make_shared<facebook::react::ContextContainer const>();
   std::shared_ptr<const facebook::react::ReactNativeConfig> reactNativeConfig =
@@ -189,7 +209,7 @@ void RNInstance::InitializeFabric() {
       return std::make_unique<AsynchronousEventBeat>(std::move(runLoopObserver), runtimeExecutor);
   };
   mountingManager_ =
-      std::make_unique<MountingManager>(componentViewRegistry_.get());
+      std::make_unique<MountingManager>(componentViewRegistry_.get(), rendererDelegate);
   fabricScheduler_ =
       std::make_shared<Scheduler>(toolbox, nullptr, mountingManager_.get());
 }

--- a/ReactSkia/RNInstance.h
+++ b/ReactSkia/RNInstance.h
@@ -2,8 +2,14 @@
 
 #include "cxxreact/Instance.h"
 
+namespace RnsShell {
+  class RendererDelegate;
+}
+
 namespace facebook {
 namespace react {
+
+using namespace RnsShell;
 
 class ComponentViewRegistry;
 class JSITurboModuleManager;
@@ -13,16 +19,16 @@ class RSkSurfaceWindow;
 
 class RNInstance {
  public:
-  RNInstance();
+  RNInstance(RendererDelegate &rendererDelegate);
   ~RNInstance();
   RNInstance(RNInstance &&) = default;
 
-  void Start(RSkSurfaceWindow *surface);
-  void Stop();
+  void Start(RSkSurfaceWindow *surface, RendererDelegate &rendererDelegate);
+  void Stop(RSkSurfaceWindow *surface);
 
  private:
   void InitializeJSCore();
-  void InitializeFabric();
+  void InitializeFabric(RendererDelegate &rendererDelegate);
   void RegisterComponents();
 
  private:

--- a/ReactSkia/RSkSurfaceWindow.cpp
+++ b/ReactSkia/RSkSurfaceWindow.cpp
@@ -13,24 +13,19 @@ GrDirectContext* RSkSurfaceWindow::directContext=nullptr;
 #endif
 
 RSkSurfaceWindow::RSkSurfaceWindow() {
-  SkRect viewPort(SkRect::MakeEmpty());
-  compositor_ = Compositor::create(viewPort);
-#ifdef RNS_SHELL_HAS_GPU_SUPPORT
-  if(compositor_) {
-    setDirectContext(compositor_->getDirectContext());
-  }
-#endif
+  RNS_LOG_TODO("Need to come up with proper way to set surfaceId, moduleName and properties members");
+  surfaceId = 1;
+  moduleName = "SimpleViewApp";
+  properties = folly::dynamic::object();
+
 }
 
 RSkSurfaceWindow::~RSkSurfaceWindow() {
-  compositor_->invalidate();
-  compositor_.reset();
 }
 
-LayoutConstraints RSkSurfaceWindow::GetLayoutConstraints() {
-  Size windowSize{static_cast<Float>(compositor_->viewport().width()),
-                  static_cast<Float>(compositor_->viewport().height())};
-  return {windowSize, windowSize};
+void RSkSurfaceWindow::setSize(SkSize size) {
+  RNS_LOG_INFO("Set Layout MinMax Size : " << size.width() << "x" << size.height());
+  minimumSize = maximumSize = size;
 }
 
 #ifdef RNS_SHELL_HAS_GPU_SUPPORT

--- a/ReactSkia/RSkSurfaceWindow.h
+++ b/ReactSkia/RSkSurfaceWindow.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include "cxxreact/Instance.h"
+
 #include "react/renderer/core/LayoutConstraints.h"
+#include "react/renderer/core/ReactPrimitives.h"
 
 #include "rns_shell/compositor/Compositor.h"
 
@@ -19,22 +22,26 @@ class RSkSurfaceWindow {
 
   ~RSkSurfaceWindow();
 
-  RnsShell::Compositor* compositor() { return compositor_.get(); }
-
-  LayoutConstraints GetLayoutConstraints();
+  void setSize(SkSize size);
 
 #ifdef RNS_SHELL_HAS_GPU_SUPPORT
 // Interfaces to expose direct context of GPU backend
   static GrDirectContext* directContext;
-  static void setDirectContext(GrDirectContext*);
   static GrDirectContext* getDirectContext(){return  RSkSurfaceWindow::directContext;};
+  void setDirectContext(GrDirectContext*);
 #endif
+
+  SurfaceId surfaceId;
+  std::string moduleName;
+  folly::dynamic properties;
+  SkSize minimumSize {0, 0};
+  SkSize maximumSize {1920, 1080};
+  SkPoint viewportOffset {0, 0};
 
  private:
   void RecreateWindowBackend();
 
  private:
-  std::unique_ptr<RnsShell::Compositor> compositor_;
 };
 
 } // namespace react

--- a/ReactSkia/ReactSkiaApp.cpp
+++ b/ReactSkia/ReactSkiaApp.cpp
@@ -2,7 +2,6 @@
 
 #include "include/core/SkCanvas.h"
 #include "include/core/SkFont.h"
-#include "include/core/SkGraphics.h"
 #include "include/core/SkSurface.h"
 #include "include/effects/SkGradientShader.h"
 
@@ -11,25 +10,35 @@
 using namespace RnsShell;
 
 Application *Application::Create(int argc, char **argv) {
-  return new ReactSkiaApp(argc, argv);
+  return new facebook::react::ReactSkiaApp(argc, argv);
 }
 
+namespace facebook {
+namespace react {
+
 ReactSkiaApp::ReactSkiaApp(int argc, char **argv) {
-  rnInstance_ = std::make_unique<facebook::react::RNInstance>();
   surface_ = std::make_unique<facebook::react::RSkSurfaceWindow>();
-  SkGraphics::Init();
-  facebook::react::RSkImageCacheManager::configure();//Needs to be called after Gpu backend created,So calling here
-  rnInstance_->Start(surface_.get());
+  surface_->setSize(viewPort());
+#ifdef RNS_SHELL_HAS_GPU_SUPPORT
+  surface_->setDirectContext(graphicsDirectContext());
+#endif
+  rnInstance_ = std::make_unique<facebook::react::RNInstance>(*this);
+  rnInstance_->Start(surface_.get(), *this);
+
+  RSkImageCacheManager::configure();//Needs to be called after Gpu backend created,So calling here
 }
 
 ReactSkiaApp::~ReactSkiaApp() {
-  rnInstance_->Stop();
+  rnInstance_->Stop(surface_.get());
 }
 
 void ReactSkiaApp::onIdle() {
   RNS_LOG_NOT_IMPL;
 }
 
-void ReactSkiaApp::onResize(int width, int height) {
-  surface_->compositor()->setViewportSize(SkRect::MakeWH(width, height));
+void ReactSkiaApp::onResize(SkSize newSize) {
+  surface_->setSize(newSize);
 }
+
+} // namespace react
+} // namespace facebook

--- a/ReactSkia/ReactSkiaApp.h
+++ b/ReactSkia/ReactSkiaApp.h
@@ -7,6 +7,9 @@
 
 class SkCanvas;
 
+namespace facebook {
+namespace react {
+
 class ReactSkiaApp : public RnsShell::Application {
  public:
 
@@ -14,9 +17,12 @@ class ReactSkiaApp : public RnsShell::Application {
   ~ReactSkiaApp();
 
   void onIdle();
-  void onResize(int width, int height);
+  void onResize(SkSize newSize);
 
  private:
   std::unique_ptr<facebook::react::RNInstance> rnInstance_;
   std::unique_ptr<facebook::react::RSkSurfaceWindow> surface_;
 };
+
+} // namespace react
+} // namespace facebook

--- a/ReactSkia/components/RSkComponent.cpp
+++ b/ReactSkia/components/RSkComponent.cpp
@@ -10,8 +10,10 @@
 namespace facebook {
 namespace react {
 
+using namespace RnsShell;
+
 RSkComponent::RSkComponent(const ShadowView &shadowView)
-    : INHERITED(RnsShell::LAYER_TYPE_DEFAULT)
+    : INHERITED(Layer::EmptyClient::singleton(), LAYER_TYPE_DEFAULT)
     , parent_(nullptr)
     , absOrigin_(shadowView.layoutMetrics.frame.origin)
     , component_(shadowView)
@@ -45,13 +47,15 @@ sk_sp<SkPicture> RSkComponent::getPicture() {
   return recorder.finishRecordingAsPicture();
 }
 
-void RSkComponent::requiresLayer(const ShadowView &shadowView) {
+void RSkComponent::requiresLayer(const ShadowView &shadowView, Layer::Client& layerClient) {
     // Need to come up with rules to decide wheather we need to create picture layer, texture layer etc"
     // Text components paragraph builder is not compatabile with Picture layer,so use default layer
-    if(strcmp(component_.componentName,"Paragraph") == 0)
+    if(strcmp(component_.componentName,"Paragraph") == 0) {
         layer_ = this->shared_from_this();
+        layer_->setClient(layerClient); // Need to set client for Default layer type.
+    }
     else
-        layer_ = RnsShell::Layer::Create(RnsShell::LAYER_TYPE_PICTURE);
+        layer_ = Layer::Create(layerClient, LAYER_TYPE_PICTURE);
 }
 
 RnsShell::LayerInvalidateMask RSkComponent::updateProps(const ShadowView &newShadowView,bool forceUpdate) {

--- a/ReactSkia/components/RSkComponent.h
+++ b/ReactSkia/components/RSkComponent.h
@@ -12,6 +12,8 @@
 namespace facebook {
 namespace react {
 
+using namespace RnsShell;
+
 enum ComponentUpdateMask {
   ComponentUpdateMaskNone = 0,
   ComponentUpdateMaskProps = 1 << 0,
@@ -72,7 +74,7 @@ class RSkComponent : public RnsShell::Layer, public std::enable_shared_from_this
   Component getComponentData() { return component_;}
   std::shared_ptr<RnsShell::Layer> layer() { return layer_; }
   const SkIRect& getLayerAbsoluteFrame(){ return(layer_->absoluteFrame());}
-  void requiresLayer(const ShadowView &shadowView);
+  void requiresLayer(const ShadowView &shadowView, Layer::Client& layerClient);
   RSkComponent *getParent() {return parent_; };
 
   RnsShell::LayerInvalidateMask updateProps(const ShadowView &newShadowView , bool forceUpdate);

--- a/ReactSkia/views/common/RSkConversion.h
+++ b/ReactSkia/views/common/RSkConversion.h
@@ -45,3 +45,11 @@ inline SkColor RSkColorFromSharedColor(facebook::react::SharedColor sharedColor,
     }
     return defaultColor;
 }
+
+inline facebook::react::Point RCTPointFromSkPoint(const SkPoint &point) {
+  return {point.x(), point.y()};
+}
+
+inline facebook::react::Size RCTSizeFromSkSize(const SkSize &size) {
+  return {size.width(), size.height()};
+}

--- a/rns_shell/BUILD.gn
+++ b/rns_shell/BUILD.gn
@@ -96,13 +96,18 @@ if(is_linux && gl_display_backend == "libwpe") {
 source_set("rns_shell") {
 
   sources = [
-    "Application.h",
+    "common/Application.h",
+    "common/Application.cpp",
     "common/Window.h",
     "common/Window.cpp",
     "common/WindowContext.h",
     "common/WindowContext.cpp",
     "common/Performance.h",
     "common/Performance.cpp",
+    "compositor/LayerTreeHost.h",
+    "compositor/LayerTreeHost.cpp",
+    "compositor/RendererDelegate.h",
+    "compositor/RendererDelegate.cpp",
     "compositor/Compositor.h",
     "compositor/Compositor.cpp",
     "compositor/layers/Layer.h",

--- a/rns_shell/common/Application.cpp
+++ b/rns_shell/common/Application.cpp
@@ -1,0 +1,37 @@
+/*
+* Copyright 2016 Google Inc.
+* Copyright (C) 1994-2021 OpenTV, Inc. and Nagravision S.A.
+*
+* Use of this source code is governed by a BSD-style license that can be
+* found in the LICENSE file.
+*/
+#include "include/core/SkGraphics.h"
+#include "Application.h"
+
+namespace RnsShell {
+
+
+Application::Application()
+    : INHERITED(*this) {
+  SkGraphics::Init();
+  windowScreenChanged(layerTreeHost_->displayID());
+}
+
+void Application::windowScreenChanged(PlatformDisplayID displayId) {
+  if(displayId == displayID_)
+    return;
+  displayID_ = displayId;
+}
+
+uint32_t Application::identifier() {
+  RNS_LOG_TODO("Identify App with unique ID");
+  return 7;
+}
+
+void Application::sizeChanged(int width, int height) {
+  SkSize newSize = SkSize::Make(width, height);
+  onResize(newSize);
+  layerTreeHost_->sizeDidChange(newSize);
+}
+
+}   // namespace RnsShell

--- a/rns_shell/common/Application.h
+++ b/rns_shell/common/Application.h
@@ -7,14 +7,28 @@
 
 #pragma once
 
+#include<string>
+
+#include "compositor/RendererDelegate.h"
+
 namespace RnsShell {
 
-class Application {
+class Application : public RendererDelegate {
 public:
     static Application* Create(int argc, char** argv);
+    Application();
     virtual ~Application() {}
 
-    virtual void onResize(int width, int height) = 0;
+    PlatformDisplayID displayID() const { return displayID_; }
+    uint32_t identifier();
+    void sizeChanged(int width, int height);
+    virtual void onResize(SkSize newSize) = 0;
+
+private:
+    PlatformDisplayID displayID_ { 0 };
+    void windowScreenChanged(PlatformDisplayID displayId);
+
+    typedef RendererDelegate INHERITED;
 };
 
 }   // namespace RnsShell

--- a/rns_shell/compositor/Compositor.h
+++ b/rns_shell/compositor/Compositor.h
@@ -9,7 +9,6 @@
 
 #include "third_party/skia/include/core/SkRect.h"
 
-#include "Window.h"
 #include "WindowContext.h"
 #include "PlatformDisplay.h"
 #include "layers/Layer.h"
@@ -18,18 +17,26 @@
 
 namespace RnsShell {
 
+typedef uint64_t PlatformDisplayID;
+
 class Compositor {
     RNS_MAKE_NONCOPYABLE(Compositor);
 public:
 
-    static std::unique_ptr<Compositor> create(SkRect& viewPort, float scaleFactor = 1.0);
-    Compositor(SkRect& viewPort, float scaleFactor);
+    class Client {
+    public:
+        virtual uint64_t nativeSurfaceHandle() = 0;
+        virtual void didRenderFrame() = 0;
+    };
+
+    static std::unique_ptr<Compositor> create(Client&, PlatformDisplayID, SkSize&, float scaleFactor = 1.0);
+    Compositor(Client&, PlatformDisplayID, SkSize&, float);
     virtual ~Compositor();
 
     Layer* rootLayer() { return rootLayer_.get(); }
     void setRootLayer(SharedLayer rootLayer);
-    void setViewportSize(const SkRect& viewportSize);
-    SkRect& viewport() { return attributes_.viewportSize; }
+    void setViewportSize(const SkSize& viewportSize);
+    SkSize& viewport() { return attributes_.viewportSize; }
     void invalidate();
     void begin(); // Call this before modifying render layer tree
     void commit(); // Commit the changes in render layer tree
@@ -51,8 +58,8 @@ private:
 
     std::mutex isMutating; // Lock the renderLayer tree while updating and rendering
 
+    Client& client_;
     SharedLayer rootLayer_;
-    std::unique_ptr<Window> window_;
     std::unique_ptr<WindowContext> windowContext_;
     sk_sp<SkSurface> backBuffer_;
     uint64_t nativeWindowHandle_;
@@ -64,7 +71,7 @@ private:
 
     struct {
         //Lock lock;
-        SkRect viewportSize;
+        SkSize viewportSize;
         float scaleFactor { 1 };
         bool needsResize { false };
         bool rendersNextFrame { false };

--- a/rns_shell/compositor/LayerTreeHost.cpp
+++ b/rns_shell/compositor/LayerTreeHost.cpp
@@ -1,0 +1,56 @@
+/*
+* Copyright (C) 1994-2021 OpenTV, Inc. and Nagravision S.A.
+*
+* Use of this source code is governed by a BSD-style license that can be
+* found in the LICENSE file.
+*/
+
+#include "Window.h"
+#include "LayerTreeHost.h"
+#include "rns_shell/common/Application.h"
+
+namespace RnsShell {
+
+LayerTreeHost::LayerTreeHost(Application& app)
+    : app_(app),
+      window_(Window::createNativeWindow(&PlatformDisplay::sharedDisplayForCompositing())),
+      compositorClient_(*this),
+      displayID_(std::numeric_limits<uint32_t>::max() - app_.identifier()) {
+  SkSize viewPort(SkSize::MakeEmpty());
+  compositor_ = Compositor::create(compositorClient_, displayID_, viewPort);
+}
+
+LayerTreeHost::~LayerTreeHost() {
+  //TODO cancel Pending schedules
+  compositor_->invalidate();
+  compositor_.reset();
+  window_ = nullptr;
+}
+
+uint64_t LayerTreeHost::nativeSurfaceHandle() {
+  return window_->nativeWindowHandle();
+}
+
+void LayerTreeHost::didRenderFrame() {
+  if(window_)
+    window_->didRenderFrame();
+}
+
+void LayerTreeHost::sizeDidChange(SkSize& size) {
+  compositor_->setViewportSize(size);
+}
+
+void LayerTreeHost::begin() {
+  compositor_->begin();
+}
+
+void LayerTreeHost::commitScene() {
+  // TODO Check compositor state idle, progress, scheduled
+  compositor_->commit();
+}
+
+void LayerTreeHost::setRootCompositingLayer(SharedLayer rootLayer) {
+  compositor_->setRootLayer(rootLayer);
+}
+
+}   // namespace RnsShell

--- a/rns_shell/compositor/LayerTreeHost.h
+++ b/rns_shell/compositor/LayerTreeHost.h
@@ -1,0 +1,55 @@
+/*
+* Copyright (C) 1994-2021 OpenTV, Inc. and Nagravision S.A.
+*
+* Use of this source code is governed by a BSD-style license that can be
+* found in the LICENSE file.
+*/
+#pragma once
+
+#include "PlatformDisplay.h"
+#include "Compositor.h"
+
+namespace RnsShell {
+class Application;
+class Window;
+
+class LayerTreeHost {
+ public:
+
+  LayerTreeHost(Application& client);
+  virtual ~LayerTreeHost();
+
+  void setRootCompositingLayer(SharedLayer rootLayer);
+  void begin();
+  void commitScene();
+  void sizeDidChange(SkSize& size);
+
+  PlatformDisplayID displayID() const { return displayID_; }
+  Compositor* compositor() { return compositor_.get(); }
+
+ private:
+  class CompositorClient : public Compositor::Client {
+    RNS_MAKE_NONCOPYABLE(CompositorClient);
+
+   public:
+    CompositorClient(LayerTreeHost& layerTreeHost)
+        : layerTreeHost_(layerTreeHost) { }
+    ~CompositorClient(){};
+
+   private:
+    uint64_t nativeSurfaceHandle() override { return layerTreeHost_.nativeSurfaceHandle(); }
+    void didRenderFrame() override { layerTreeHost_.didRenderFrame(); }
+    LayerTreeHost& layerTreeHost_;
+  };
+
+  uint64_t nativeSurfaceHandle();
+  void didRenderFrame();
+
+  Application& app_;
+  std::unique_ptr<Window> window_;
+  CompositorClient compositorClient_;
+  std::unique_ptr<Compositor> compositor_;
+  PlatformDisplayID displayID_;
+};
+
+}   // namespace RnsShell

--- a/rns_shell/compositor/RendererDelegate.cpp
+++ b/rns_shell/compositor/RendererDelegate.cpp
@@ -36,8 +36,11 @@ void RendererDelegate::setRootLayer(SharedLayer rootLayer) {
 }
 
 void RendererDelegate::scheduleRenderingUpdate() {
-  RNS_LOG_NOT_IMPL;
   commit();
+}
+
+void RendererDelegate::beginRenderingUpdate() {
+  begin();
 }
 
 

--- a/rns_shell/compositor/RendererDelegate.cpp
+++ b/rns_shell/compositor/RendererDelegate.cpp
@@ -1,0 +1,44 @@
+/*
+* Copyright (C) 1994-2021 OpenTV, Inc. and Nagravision S.A.
+*
+* Use of this source code is governed by a BSD-style license that can be
+* found in the LICENSE file.
+*/
+
+#include "RendererDelegate.h"
+
+namespace RnsShell {
+
+RendererDelegate::RendererDelegate(Application& app) {
+  layerTreeHost_ = std::make_unique<LayerTreeHost>(app);
+}
+
+SkSize RendererDelegate::viewPort() {
+  return(layerTreeHost_->compositor()->viewport());
+}
+
+#ifdef RNS_SHELL_HAS_GPU_SUPPORT
+GrDirectContext* RendererDelegate::graphicsDirectContext() {
+  return(layerTreeHost_->compositor()->getDirectContext());
+}
+#endif
+
+void RendererDelegate::begin() {
+  layerTreeHost_->begin();
+}
+
+void RendererDelegate::commit() {
+  layerTreeHost_->commitScene();
+}
+
+void RendererDelegate::setRootLayer(SharedLayer rootLayer) {
+  layerTreeHost_->setRootCompositingLayer(rootLayer);
+}
+
+void RendererDelegate::scheduleRenderingUpdate() {
+  RNS_LOG_NOT_IMPL;
+  commit();
+}
+
+
+}   // namespace RnsShell

--- a/rns_shell/compositor/RendererDelegate.h
+++ b/rns_shell/compositor/RendererDelegate.h
@@ -21,13 +21,14 @@ public:
 #endif
     SkSize viewPort();
     void scheduleRenderingUpdate();
+    void beginRenderingUpdate();
     void setRootLayer(SharedLayer rootLayer);
     void commit();
     void begin();
 
     // Layer Client Implementation
     void notifyFlushRequired() override { scheduleRenderingUpdate(); }
-    void notifyFlushBegin() override { begin(); }
+    void notifyFlushBegin() override { beginRenderingUpdate(); }
 
 protected:
     std::unique_ptr<LayerTreeHost> layerTreeHost_;

--- a/rns_shell/compositor/RendererDelegate.h
+++ b/rns_shell/compositor/RendererDelegate.h
@@ -27,6 +27,7 @@ public:
 
     // Layer Client Implementation
     void notifyFlushRequired() override { scheduleRenderingUpdate(); }
+    void notifyFlushBegin() override { begin(); }
 
 protected:
     std::unique_ptr<LayerTreeHost> layerTreeHost_;

--- a/rns_shell/compositor/RendererDelegate.h
+++ b/rns_shell/compositor/RendererDelegate.h
@@ -1,0 +1,35 @@
+/*
+* Copyright (C) 1994-2021 OpenTV, Inc. and Nagravision S.A.
+*
+* Use of this source code is governed by a BSD-style license that can be
+* found in the LICENSE file.
+*/
+
+#pragma once
+
+#include "compositor/LayerTreeHost.h"
+
+namespace RnsShell {
+
+class RendererDelegate : public RnsShell::Layer::Client {
+public:
+    RendererDelegate(Application& app);
+    virtual ~RendererDelegate() {}
+
+#ifdef RNS_SHELL_HAS_GPU_SUPPORT
+    GrDirectContext* graphicsDirectContext();
+#endif
+    SkSize viewPort();
+    void scheduleRenderingUpdate();
+    void setRootLayer(SharedLayer rootLayer);
+    void commit();
+    void begin();
+
+    // Layer Client Implementation
+    void notifyFlushRequired() override { scheduleRenderingUpdate(); }
+
+protected:
+    std::unique_ptr<LayerTreeHost> layerTreeHost_;
+};
+
+}   // namespace RnsShell

--- a/rns_shell/compositor/layers/Layer.cpp
+++ b/rns_shell/compositor/layers/Layer.cpp
@@ -21,10 +21,10 @@ static inline void addDamageRect(PaintContext& context, SkIRect dirtyAbsFrameRec
 }
 #endif
 
-SharedLayer Layer::Create(LayerType type) {
+SharedLayer Layer::Create(Client& layerClient, LayerType type) {
     switch(type) {
         case LAYER_TYPE_PICTURE:
-            return std::make_shared<PictureLayer>();
+            return std::make_shared<PictureLayer>(layerClient);
         case LAYER_TYPE_DEFAULT:
         default:
             RNS_LOG_ASSERT(false, "Default layers can be created only from RSkComponent constructor");
@@ -41,15 +41,21 @@ uint64_t Layer::nextUniqueId() {
     return id;
 }
 
-Layer::Layer(LayerType type)
+Layer::EmptyClient& Layer::EmptyClient::singleton() {
+    static Layer::EmptyClient client;
+    return client;
+}
+
+Layer::Layer(Client& layerClient, LayerType type)
     : layerId_(nextUniqueId())
     , parent_(nullptr)
     , type_(type)
+    , client_(&layerClient)
     , frame_(SkIRect::MakeEmpty())
     , absFrame_(SkIRect::MakeEmpty())
     , anchorPosition_(SkPoint::Make(0.5,0.5)) // Default anchor point as centre
     , invalidateMask_(LayerInvalidateAll) {
-    RNS_LOG_DEBUG("Layer Constructed(" << this << ") with ID : " << layerId_);
+    RNS_LOG_DEBUG("Layer Constructed(" << this << ") with ID : " << layerId_ << " and LayerClient : " << client_);
 }
 
 Layer* Layer::rootLayer() {

--- a/rns_shell/compositor/layers/Layer.h
+++ b/rns_shell/compositor/layers/Layer.h
@@ -58,6 +58,7 @@ public:
     public:
         virtual ~Client() = default;
         virtual void notifyFlushRequired() { }
+        virtual void notifyFlushBegin() { }
     };
 
     // Singleton defualt client used for default layers.

--- a/rns_shell/compositor/layers/PictureLayer.cpp
+++ b/rns_shell/compositor/layers/PictureLayer.cpp
@@ -10,13 +10,13 @@
 
 namespace RnsShell {
 
-SharedPictureLayer PictureLayer::Create() {
-    return std::make_shared<PictureLayer>();
+SharedPictureLayer PictureLayer::Create(Client& layerClient) {
+    return std::make_shared<PictureLayer>(layerClient);
 }
 
-PictureLayer::PictureLayer()
-    : INHERITED(LAYER_TYPE_PICTURE) {
-    RNS_LOG_INFO("Picture Layer Constructed(" << this << ") with ID : " << layerId());
+PictureLayer::PictureLayer(Client& layerClient)
+    : INHERITED(layerClient, LAYER_TYPE_PICTURE) {
+    RNS_LOG_INFO("Picture Layer Constructed(" << this << ") with ID : " << layerId() << " and LayerClient : " << &layerClient);
 }
 
 void PictureLayer::prePaint(PaintContext& context, bool forceLayout) {

--- a/rns_shell/compositor/layers/PictureLayer.h
+++ b/rns_shell/compositor/layers/PictureLayer.h
@@ -19,8 +19,8 @@ using SharedPictureLayer = std::shared_ptr<PictureLayer>;
 class PictureLayer : public Layer {
 public:
 
-    static SharedPictureLayer Create();
-    PictureLayer();
+    static SharedPictureLayer Create(Client& layerClient);
+    PictureLayer(Client& layerClient);
     virtual ~PictureLayer() {};
 
     SkPicture* picture() const { return picture_.get(); }

--- a/rns_shell/platform/graphics/gl/GLWindowContext.h
+++ b/rns_shell/platform/graphics/gl/GLWindowContext.h
@@ -12,7 +12,9 @@
 #define GL_GLEXT_PROTOTYPES 1
 #if USE(OPENGL_ES)
 #include <GLES2/gl2.h>
+#if defined(GL_ES_VERSION_3_0) && GL_ES_VERSION_3_0
 #include <GLES3/gl3.h>
+#endif
 #include <GLES2/gl2ext.h>
 #else
 #include <GL/gl.h>

--- a/rns_shell/platform/graphics/gl/egl/GLWindowContextEGL.cpp
+++ b/rns_shell/platform/graphics/gl/egl/GLWindowContextEGL.cpp
@@ -28,7 +28,11 @@ static const char* gEGLAPIName = "OpenGL";
 static const EGLenum gEGLAPIVersion = EGL_OPENGL_API;
 #endif
 
+#if defined(EGL_EXT_swap_buffers_with_damage) && EGL_EXT_swap_buffers_with_damage
 static PFNEGLSWAPBUFFERSWITHDAMAGEEXTPROC eglSwapBuffersWithDamage = nullptr;
+#else
+static void* eglSwapBuffersWithDamage = nullptr;
+#endif
 
 const char* GLWindowContextEGL::errorString(int statusCode) {
     static_assert(sizeof(int) >= sizeof(EGLint), "EGLint must not be wider than int");
@@ -428,6 +432,7 @@ void GLWindowContextEGL::swapInterval() {
             RNS_LOG_INFO("EGL_KHR_partial_update extenstion supported....");
         }
 
+#if defined(EGL_EXT_swap_buffers_with_damage) && EGL_EXT_swap_buffers_with_damage
         if (isExtensionSupported(extensions, "EGL_EXT_swap_buffers_with_damage")) {
             RNS_LOG_INFO("EGL_EXT_swap_buffers_with_damage extenstion supported....");
             eglSwapBuffersWithDamage =  reinterpret_cast<PFNEGLSWAPBUFFERSWITHDAMAGEEXTPROC>(eglGetProcAddress("eglSwapBuffersWithDamageEXT"));
@@ -435,6 +440,7 @@ void GLWindowContextEGL::swapInterval() {
             RNS_LOG_INFO("EGL_KHR_swap_buffers_with_damage extenstion supported....");
             eglSwapBuffersWithDamage =  reinterpret_cast<PFNEGLSWAPBUFFERSWITHDAMAGEEXTPROC>(eglGetProcAddress("eglSwapBuffersWithDamageKHR"));
         }
+#endif
     }
 
     eglSwapInterval(platformDisplay_.eglDisplay(), displayParams_.disableVsync_ ? 0 : 1);

--- a/rns_shell/platform/graphics/libwpe/WindowLibWPE.cpp
+++ b/rns_shell/platform/graphics/libwpe/WindowLibWPE.cpp
@@ -186,7 +186,7 @@ bool WindowLibWPE::initWindow(PlatformDisplay *platformDisplay) {
     gWindowMap.add(this);
 
     if(WindowLibWPE::mainApp_)
-        WindowLibWPE::mainApp_->onResize(viewWidth_, viewHeight_);
+        WindowLibWPE::mainApp_->sizeChanged(viewWidth_, viewHeight_);
 
     return true;
 }
@@ -198,7 +198,7 @@ void WindowLibWPE::setViewSize(int width, int height) {
     viewWidth_ = width;
     viewHeight_ = height;
     if(WindowLibWPE::mainApp_)
-        WindowLibWPE::mainApp_->onResize(viewWidth_, viewHeight_);
+        WindowLibWPE::mainApp_->sizeChanged(viewWidth_, viewHeight_);
 }
 
 void WindowLibWPE::closeWindow() {

--- a/rns_shell/platform/graphics/x11/WindowX11.cpp
+++ b/rns_shell/platform/graphics/x11/WindowX11.cpp
@@ -59,7 +59,7 @@ void Window::createEventLoop(Application* app) {
                     case ConfigureNotify:
                         RNS_LOG_INFO("Resize Request with (Width x Height) : (" << event.xconfigurerequest.width <<
                                     " x " << event.xconfigurerequest.height << ")");
-                        app->onResize(event.xconfigurerequest.width, event.xconfigurerequest.height);
+                        app->sizeChanged(event.xconfigurerequest.width, event.xconfigurerequest.height);
                         break;
                     default:
                         WindowX11* win = WindowX11::gWindowMap.find(event.xany.window);


### PR DESCRIPTION
    * Extended RSkSurfaceWindow class to improve app surface and layout handling.
    
    Added surfaceId, module name , properties, viewport offset and size members in RSkSurfaceWindow
    Added inline functions to calculate LayoutCOntext and LayoutConstraints RNInstance
    Added two more helper functions in RSKConversion.h
    
    * Fixed compositor viewportSize type.
    
    ViewPort Size only holds width and hight and not offset.
    Changed Viewport data type from SkRect to SkSize
    
    * Added LayerTreeHost and RendererDelegate in Rns Shell
    
    Now compositor will be part of LayerTreeHost and Application class will hold both LayerTreeHost
    and RendererDelegate.
    Update ReactSkia code to incorporate LayerTreeHost and RendererDelegate changes in Rns Shell
    
    * Added Layer Client support which can be used to delegate layer/frame flush/begin.
    
    Now Layer can trigger display/frame update using layer client's notifyFlushBegin() and notifyFlushRequired()
    
    * Renderer delegate will return GrDirectionContext now
    
    This was required for image cache manager and since we rearanged code for layerTreeHost,
    we had to expose one API in renderer delegate to get this GrDirection context from composito

    * Added extra opengl checks to avoid compilation issues in certain opengl enabled platforms.
