### PR TITLE
Refactor "Fix layer be removed when reused (#57)"

### DIFF
--- a/ReactSkia/components/RSkComponent.cpp
+++ b/ReactSkia/components/RSkComponent.cpp
@@ -302,12 +302,8 @@ void RSkComponent::mountChildComponent(
     if(newChildComponent) {
         newChildComponent->parent_ = this;
         RNS_LOG_ASSERT((this->layer_ && newChildComponent->layer_), "Layer Object cannot be null");
-        if(this->layer_) {
+        if(this->layer_)
             this->layer_->insertChild(newChildComponent->layer_, index);
-        }
-        if (newChildComponent->layer_) {
-            newChildComponent->layer_->removeInvalidate(RnsShell::LayerRemoveInvalidate);
-        }
 
         SpatialNavigator::Container *containerToAdd = nullptr;
         if(isContainer() == true || ((containerToAdd = nearestAncestorContainer()) == nullptr))

--- a/rns_shell/compositor/layers/Layer.cpp
+++ b/rns_shell/compositor/layers/Layer.cpp
@@ -128,6 +128,8 @@ void Layer::insertChild(SharedLayer child, size_t index) {
 
     child->removeFromParent();
     child->setParent(this);
+    // Reset the remove invalidate flag when the child layer is reused
+    child->invalidateMask_ = static_cast<RnsShell::LayerInvalidateMask>(child->invalidateMask_ & ~LayerRemoveInvalidate);
 
     index = std::min(index, children_.size());
     RNS_LOG_DEBUG("Insert Child(" << child.get()->layerId() << ") at index : " << index << " and with parent : " << layerId_);

--- a/rns_shell/compositor/layers/Layer.h
+++ b/rns_shell/compositor/layers/Layer.h
@@ -125,9 +125,6 @@ public:
     const SkIRect& getFrame() const { return frame_; }
     void setFrame(const SkIRect& frame) { frame_ = frame; }
     void invalidate(LayerInvalidateMask mask = LayerInvalidateAll) { invalidateMask_ = static_cast<RnsShell::LayerInvalidateMask>(invalidateMask_ | mask); }
-    void removeInvalidate(LayerInvalidateMask removeMask) {
-      invalidateMask_ = static_cast<RnsShell::LayerInvalidateMask>(invalidateMask_ & ~removeMask);
-    }
     bool requireInvalidate(bool skipChildren=true);
 
     const SkIRect& getBounds() const { return bounds_; }


### PR DESCRIPTION
# Why

@munezbn mentioned that we could just reset the flag in Layer.cpp and makes the code cleaner

# How

reset the `LayerRemoveInvalidate` flag when the layer is added back

# Test Plan

follow the Test Plan in as #57