### PR TITLE
Add macOS scrollview integration

### DIFF
--- a/ReactSkia/components/RSkComponent.h
+++ b/ReactSkia/components/RSkComponent.h
@@ -121,7 +121,7 @@ class RSkComponent : public SpatialNavigator::Container, public std::enable_shar
   bool isFocusable();
   bool needsShadowPainting();
 
-  void requiresLayer(const ShadowView &shadowView, RnsShell::Layer::Client& layerClient);
+  virtual void requiresLayer(const ShadowView &shadowView, RnsShell::Layer::Client& layerClient);
   RnsShell::LayerInvalidateMask updateProps(Props::Shared newProps , bool forceUpdate);
   void setNeedFocusUpdate();
  protected:

--- a/ReactSkia/components/RSkComponentScrollView.h
+++ b/ReactSkia/components/RSkComponentScrollView.h
@@ -12,6 +12,7 @@
 #include "ReactSkia/components/RSkComponent.h"
 #include "ReactSkia/RSkSurfaceWindow.h"
 #include "ReactSkia/sdk/FollyTimer.h"
+#include "rns_shell/compositor/layers/ScrollLayer.h"
 
 using namespace rns::sdk;
 namespace facebook {
@@ -27,7 +28,7 @@ enum ScrollDirectionType {
    ScrollDirectionBackward
 };
 
-class RSkComponentScrollView final : public RSkComponent {
+class RSkComponentScrollView final : public RSkComponent, public RnsShell::ScrollLayer::ScrollingClient {
  public:
   RSkComponentScrollView(const ShadowView &shadowView);
   ~RSkComponentScrollView();
@@ -46,6 +47,8 @@ class RSkComponentScrollView final : public RSkComponent {
     folly::dynamic args) override;
 
   bool isContainer() const override { return true; }
+
+  void requiresLayer(const ShadowView &shadowView, RnsShell::Layer::Client& layerClient) override;
 
   //RSkSpatialNavigatorContainer override functions
   bool canScrollInDirection(rnsKey direction) override;
@@ -95,7 +98,11 @@ class RSkComponentScrollView final : public RSkComponent {
   ScrollStatus handleScroll(int x,int y, bool isFlushDisplay=true);
   ScrollStatus handleScroll(SkPoint scrollPos, bool isFlushDisplay=true);
 
-  void dispatchOnScrollEvent(SkPoint scrollPos);
+  void dispatchOnScrollEvent(const SkPoint &scrollPos);
+
+  // RnsShell::ScrollLayer::ScrollingClient implementations
+  void layerWillScroll() override;
+  void layerDidScroll(const SkPoint &scrollPos) override;
 };
 
 } // namespace react

--- a/rns_shell/common/Window.h
+++ b/rns_shell/common/Window.h
@@ -22,6 +22,8 @@ class SkSurfaceProps;
 class SkString;
 
 namespace RnsShell {
+
+class InputEventDelegate;
 enum WindowType{
     MainWindow,
     SubWindow,
@@ -61,6 +63,8 @@ public:
 
     virtual const DisplayParams& getRequestedDisplayParams() { return requestedDisplayParams_; }
     virtual void setRequestedDisplayParams(const DisplayParams&, bool allowReattach = true);
+
+    virtual void BindInputEventDelegate(InputEventDelegate *delegate) {}
 
     // Actual parameters in effect, obtained from the native window.
     int sampleCount() const;

--- a/rns_shell/compositor/LayerTreeHost.cpp
+++ b/rns_shell/compositor/LayerTreeHost.cpp
@@ -7,16 +7,44 @@
 
 #include "rns_shell/compositor/LayerTreeHost.h"
 
+#include <vector>
+
 #include "rns_shell/common/Application.h"
 #include "rns_shell/common/Window.h"
+#include "rns_shell/compositor/layers/ScrollLayer.h"
+#include "rns_shell/input/MouseWheelEvent.h"
+#include "ReactSkia/utils/RnsLog.h"
 
 namespace RnsShell {
+
+namespace {
+
+// Runs hit-testing from layer tree to layer list.
+// React Native organizes layer tree with implicit z-index order,
+// the last layer in the list will be the topmost layer.
+void RunHitTestToLayerList(
+    Layer *root,
+    int eventX,
+    int eventY,
+    std::vector<Layer *> &result) {
+  if (root != nullptr) {
+    if (root->absoluteFrame().contains(eventX, eventY)) {
+      result.push_back(root);
+    }
+    for (auto &child : root->children()) {
+      RunHitTestToLayerList(child.get(), eventX, eventY, result);
+    }
+  }
+}
+
+} // namespace
 
 LayerTreeHost::LayerTreeHost(Application& app)
     : app_(app),
       window_(Window::createNativeWindow(&PlatformDisplay::sharedDisplayForCompositing())),
       compositorClient_(*this),
       displayID_(std::numeric_limits<uint32_t>::max() - app_.identifier()) {
+  window_->BindInputEventDelegate(this);
   SkSize viewPort(SkSize::MakeEmpty());
   compositor_ = Compositor::create(compositorClient_, displayID_, viewPort, PlatformDisplay::sharedDisplayForCompositing().scaleFactor());
 }
@@ -33,8 +61,41 @@ uint64_t LayerTreeHost::nativeSurfaceHandle() {
 }
 
 void LayerTreeHost::didRenderFrame() {
-  if(window_)
+  if (window_)
     window_->didRenderFrame();
+}
+
+// InputEventDelegate implementations
+
+void LayerTreeHost::DispatchInputEvent(MouseWheelEvent &&event) {
+  // From the topmost layer receieving the event,
+  // we should further find the scroll layer from ancestors.
+  auto *target = HitTest(event.eventX, event.eventY);
+  while (target != nullptr) {
+    if (target->type() == LAYER_TYPE_SCROLL) {
+      break;
+    }
+    target = target->parent();
+  }
+
+  if (target != nullptr) {
+    ScrollLayer *scrollLayer = static_cast<ScrollLayer *>(target);
+    SkPoint scrollPos = scrollLayer->getScrollPosition();
+    scrollPos.offset(event.deltaX, event.deltaY);
+    scrollLayer->scrollTo(scrollPos);
+  }
+}
+
+// private implementations
+
+Layer *LayerTreeHost::HitTest(int eventX, int eventY) {
+  std::vector<Layer *> candidates;
+  RunHitTestToLayerList(compositor()->rootLayer(), eventX, eventY, candidates);
+  if (!candidates.empty()) {
+    return candidates.back();
+  } else {
+    return nullptr;
+  }
 }
 
 void LayerTreeHost::sizeDidChange(SkSize& size) {

--- a/rns_shell/compositor/LayerTreeHost.h
+++ b/rns_shell/compositor/LayerTreeHost.h
@@ -7,13 +7,16 @@
 #pragma once
 
 #include "rns_shell/compositor/Compositor.h"
+#include "rns_shell/input/InputEventDelegate.h"
 #include "rns_shell/platform/graphics/PlatformDisplay.h"
 
 namespace RnsShell {
+
 class Application;
+struct MouseWheelEvent;
 class Window;
 
-class LayerTreeHost {
+class LayerTreeHost : public InputEventDelegate {
  public:
 
   LayerTreeHost(Application& client);
@@ -43,9 +46,16 @@ class LayerTreeHost {
     LayerTreeHost& layerTreeHost_;
   };
 
+private:
   uint64_t nativeSurfaceHandle();
   void didRenderFrame();
 
+  // InputEventDelegate implementations
+  void DispatchInputEvent(MouseWheelEvent &&event);
+
+  Layer* HitTest(int eventX, int eventY);
+
+private:
   Application& app_;
   std::unique_ptr<Window> window_;
   CompositorClient compositorClient_;

--- a/rns_shell/compositor/RendererDelegate.cpp
+++ b/rns_shell/compositor/RendererDelegate.cpp
@@ -47,5 +47,4 @@ void RendererDelegate::beginRenderingUpdate() {
   begin();
 }
 
-
 }   // namespace RnsShell

--- a/rns_shell/compositor/layers/ScrollLayer.h
+++ b/rns_shell/compositor/layers/ScrollLayer.h
@@ -9,6 +9,8 @@
 
 #include "rns_shell/compositor/layers/Layer.h"
 
+#include <functional>
+
 #include "include/core/SkPicture.h"
 
 namespace RnsShell {
@@ -76,14 +78,27 @@ public:
     bool setContentSize(SkISize contentSize) ;
     SkISize getContentSize() { return contentSize_;};
 
-    void setScrollPosition(SkPoint scrollPos) ;
+    bool scrollTo(const SkPoint &scrollPos, bool isFlushDisplay = true);
     SkPoint getScrollPosition() { return SkPoint::Make(scrollOffsetX_,scrollOffsetY_);};
+
+    class ScrollingClient {
+     public:
+      virtual ~ScrollingClient() = default;
+
+     public:
+      virtual void layerWillScroll() = 0;
+      virtual void layerDidScroll(const SkPoint &scrollPos) = 0;
+    };
+    void RegisterScrollingClient(ScrollingClient *scrollingClient) {
+      scrollingClient_ = scrollingClient;
+    }
 
 #if ENABLE(FEATURE_SCROLL_INDICATOR)
     ScrollBar& getScrollBar() { return scrollbar_;}
 #endif
 
 private:
+    void setScrollPosition(const SkPoint &scrollPos);
 
 #if USE(SCROLL_LAYER_BITMAP)
     void bitmapConfigure();
@@ -110,6 +125,7 @@ private:
 #if ENABLE(FEATURE_SCROLL_INDICATOR)
     ScrollBar scrollbar_;   // scroll indicator bar
 #endif
+    ScrollingClient *scrollingClient_;
 
     typedef Layer INHERITED;
 };

--- a/rns_shell/input/BUILD.gn
+++ b/rns_shell/input/BUILD.gn
@@ -1,0 +1,14 @@
+# Copyright (C) 1994-2022 OpenTV, Inc. and Nagravision S.A.
+# Copyright (C) Kudo Chien.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+component("input") {
+  public = [
+    "export.h",
+    "InputEventDelegate.h",
+    "MouseWheelEvent.h",
+  ]
+
+  defines = [ "INPUT_IMPLEMENTATION" ]
+}

--- a/rns_shell/input/InputEventDelegate.h
+++ b/rns_shell/input/InputEventDelegate.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 1994-2023 OpenTV, Inc. and Nagravision S.A.
+ * Copyright (C) Kudo Chien.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "rns_shell/input/export.h"
+
+namespace RnsShell {
+
+struct MouseWheelEvent;
+
+class INPUT_EXPORT InputEventDelegate {
+ public:
+  InputEventDelegate() = default;
+  InputEventDelegate(const InputEventDelegate&) = delete;
+  InputEventDelegate& operator=(const InputEventDelegate&) = delete;
+  virtual ~InputEventDelegate() = default;
+
+  virtual void DispatchInputEvent(MouseWheelEvent &&event) = 0;
+};
+
+} // namespace RnsShell

--- a/rns_shell/input/MouseWheelEvent.h
+++ b/rns_shell/input/MouseWheelEvent.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 1994-2023 OpenTV, Inc. and Nagravision S.A.
+ * Copyright (C) Kudo Chien.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "rns_shell/input/export.h"
+
+namespace RnsShell {
+
+struct INPUT_EXPORT MouseWheelEvent {
+  int eventX;
+  int eventY;
+
+  int deltaX;
+  int deltaY;
+};
+
+} // namespace RnsShell

--- a/rns_shell/input/export.h
+++ b/rns_shell/input/export.h
@@ -1,0 +1,31 @@
+// Copyright (C) 1994-2023 OpenTV, Inc. and Nagravision S.A.
+// Copyright (C) Kudo Chien.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef RNS_SHELL_INPUT_EXPORT_H_
+#define RNS_SHELL_INPUT_EXPORT_H_
+
+#if defined(COMPONENT_BUILD)
+#if defined(WIN32)
+
+#if defined(INPUT_IMPLEMENTATION)
+#define INPUT_EXPORT __declspec(dllexport)
+#else
+#define INPUT_EXPORT __declspec(dllimport)
+#endif  // defined(INPUT_IMPLEMENTATION)
+
+#else  // defined(WIN32)
+#if defined(INPUT_IMPLEMENTATION)
+#define INPUT_EXPORT __attribute__((visibility("default")))
+#else
+#define INPUT_EXPORT
+#endif
+#endif
+
+#else  // defined(COMPONENT_BUILD)
+#define INPUT_EXPORT
+#endif
+
+#endif  // RNS_SHELL_INPUT_EXPORT_H_

--- a/rns_shell/platform/mac/RootView.mm
+++ b/rns_shell/platform/mac/RootView.mm
@@ -9,6 +9,7 @@
 
 #include "rns_shell/platform/mac/RootView.h"
 
+#include "rns_shell/input/MouseWheelEvent.h"
 #include "rns_shell/platform/mac/WindowMac.h"
 
 @implementation RootView {
@@ -113,14 +114,18 @@
   //                  skui::InputState::kMove, modifiers);
 }
 
+#endif
+
 - (void)scrollWheel:(NSEvent *)event {
   [super scrollWheel:event];
   // skui::ModifierKey modifiers = [self updateModifierKeys:event];
 
-  LOG(INFO) << "mouseWheel scrollingDeltaY=" << [event scrollingDeltaY];
+  RnsShell::InputEventDelegate *delegate = window_->GetInputEventDelegate();
+  if (delegate != nullptr) {
+    RnsShell::MouseWheelEvent mouseWheelEvent({event.locationInWindow.x, event.locationInWindow.y, -event.scrollingDeltaX, -event.scrollingDeltaY});
+    delegate->DispatchInputEvent(std::move(mouseWheelEvent));
+  }
   // TODO: support hasPreciseScrollingDeltas?
-  // fWindow->onMouseWheel([event scrollingDeltaY], modifiers);
 }
-#endif
 
 @end

--- a/rns_shell/platform/mac/WindowMac.h
+++ b/rns_shell/platform/mac/WindowMac.h
@@ -15,8 +15,9 @@
 #include "include/private/SkChecksum.h"
 #include "src/core/SkTDynamicHash.h"
 
-#include "rns_shell/platform/graphics/PlatformDisplay.h"
 #include "rns_shell/common/Window.h"
+#include "rns_shell/input/InputEventDelegate.h"
+#include "rns_shell/platform/graphics/PlatformDisplay.h"
 #include "ReactSkia/sdk/NotificationCenter.h"
 #include "ReactSkia/sdk/RNSKeyCodeMapping.h"
 #include "ReactSkia/utils/RnsUtils.h"
@@ -46,11 +47,19 @@ class WindowMac : public Window {
 
   NSView *rootView();
 
+  void BindInputEventDelegate(InputEventDelegate *delegate) override {
+    inputEventDelegate_ = delegate;
+  }
+  InputEventDelegate *GetInputEventDelegate() {
+    return inputEventDelegate_;
+  }
+
  private:
   static std::map<NSInteger, WindowMac *> windowMap_;
 
   NSWindow *window_;
   PlatformDisplay *display_;
+  InputEventDelegate *inputEventDelegate_;
 };
 
 } // namespace RnsShell


### PR DESCRIPTION
# Why

Add ScrollView integration on macOS

# How

1. Introduce `InputEventDelegate` to dispatch the mouse events from macOS `RootView` to `LayerTreeHost`.
2. Introduce `LayerTreeHost::HitTest` to find the Layer top most interacting Layer.
3. `LayerTreeHost::DispatchInputEvent(MouseWheelEvent &&event)` will find the ScrollLayer to call its `scrollTo` accordingly.